### PR TITLE
[refactor] PostResponse 재설계

### DIFF
--- a/src/main/java/com/fasttime/domain/post/dto/service/response/PostDetailResponseDto.java
+++ b/src/main/java/com/fasttime/domain/post/dto/service/response/PostDetailResponseDto.java
@@ -1,10 +1,10 @@
 package com.fasttime.domain.post.dto.service.response;
 
-import com.fasttime.domain.post.entity.Post;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class PostResponseDto {
+public class PostDetailResponseDto {
 
     private final Long id;
     private final String title;
@@ -13,23 +13,14 @@ public class PostResponseDto {
     private final int likeCount;
     private final int hateCount;
 
-    private PostResponseDto(Long id, String title, String content, boolean anonymity, int likeCount,
-        int hateCount) {
+    @Builder
+    private PostDetailResponseDto(Long id, String title, String content, boolean anonymity,
+        int likeCount, int hateCount) {
         this.id = id;
         this.title = title;
         this.content = content;
         this.anonymity = anonymity;
         this.likeCount = likeCount;
         this.hateCount = hateCount;
-    }
-
-    public static PostResponseDto of(Post post) {
-
-        return new PostResponseDto(post.getId(),
-            post.getTitle(),
-            post.getContent(),
-            post.isAnonymity(),
-            post.getLikeCount(),
-            post.getHateCount());
     }
 }

--- a/src/main/java/com/fasttime/domain/post/dto/service/response/PostsResponseDto.java
+++ b/src/main/java/com/fasttime/domain/post/dto/service/response/PostsResponseDto.java
@@ -1,32 +1,26 @@
 package com.fasttime.domain.post.dto.service.response;
 
-import com.fasttime.domain.post.entity.Post;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class PostListResponseDto {
+public class PostsResponseDto {
 
     private final Long id;
     private final String title;
     private final boolean anonymity;
+    private final int commentCounts;
     private final int likeCount;
     private final int hateCount;
 
-    private PostListResponseDto(Long id, String title, boolean anonymity, int likeCount,
+    @Builder
+    private PostsResponseDto(Long id, String title, boolean anonymity, int commentCounts, int likeCount,
         int hateCount) {
         this.id = id;
         this.title = title;
         this.anonymity = anonymity;
+        this.commentCounts = commentCounts;
         this.likeCount = likeCount;
         this.hateCount = hateCount;
-    }
-
-    public static PostListResponseDto of(Post post) {
-
-        return new PostListResponseDto(post.getId(),
-            post.getTitle(),
-            post.isAnonymity(),
-            post.getLikeCount(),
-            post.getHateCount());
     }
 }

--- a/src/main/java/com/fasttime/domain/post/service/PostCommandService.java
+++ b/src/main/java/com/fasttime/domain/post/service/PostCommandService.java
@@ -6,7 +6,7 @@ import com.fasttime.domain.member.repository.MemberRepository;
 import com.fasttime.domain.post.dto.service.request.PostCreateServiceDto;
 import com.fasttime.domain.post.dto.service.request.PostDeleteServiceDto;
 import com.fasttime.domain.post.dto.service.request.PostUpdateServiceDto;
-import com.fasttime.domain.post.dto.service.response.PostResponseDto;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.exception.NotPostWriterException;
 import com.fasttime.domain.post.exception.PostNotFoundException;
@@ -26,7 +26,7 @@ public class PostCommandService {
         this.postRepository = postRepository;
     }
 
-    public PostResponseDto writePost(PostCreateServiceDto serviceDto) {
+    public PostDetailResponseDto writePost(PostCreateServiceDto serviceDto) {
 
         Member member = memberRepository.findById(serviceDto.getMemberId())
             .orElseThrow(() -> new UserNotFoundException("회원 정보가 없습니다."));
@@ -36,10 +36,17 @@ public class PostCommandService {
 
         Post savedPost = postRepository.save(createdPost);
 
-        return PostResponseDto.of(savedPost);
+        return PostDetailResponseDto.builder()
+            .id(savedPost.getId())
+            .title(savedPost.getTitle())
+            .content(savedPost.getContent())
+            .anonymity(savedPost.isAnonymity())
+            .likeCount(savedPost.getLikeCount())
+            .hateCount(savedPost.getHateCount())
+            .build();
     }
 
-    public PostResponseDto updatePost(PostUpdateServiceDto serviceDto) {
+    public PostDetailResponseDto updatePost(PostUpdateServiceDto serviceDto) {
 
         Post post = findPostById(serviceDto);
 
@@ -47,7 +54,14 @@ public class PostCommandService {
 
         post.update(serviceDto.getContent());
 
-        return PostResponseDto.of(post);
+        return PostDetailResponseDto.builder()
+            .id(post.getId())
+            .title(post.getTitle())
+            .content(post.getContent())
+            .anonymity(post.isAnonymity())
+            .likeCount(post.getLikeCount())
+            .hateCount(post.getHateCount())
+            .build();
     }
 
     public void deletePost(PostDeleteServiceDto serviceDto) {

--- a/src/main/java/com/fasttime/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fasttime/domain/post/service/PostQueryService.java
@@ -1,7 +1,7 @@
 package com.fasttime.domain.post.service;
 
-import com.fasttime.domain.post.dto.service.response.PostListResponseDto;
-import com.fasttime.domain.post.dto.service.response.PostResponseDto;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
+import com.fasttime.domain.post.dto.service.response.PostsResponseDto;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.repository.PostRepository;
 import java.util.List;
@@ -20,17 +20,30 @@ public class PostQueryService {
         this.postRepository = postRepository;
     }
 
-    public PostResponseDto searchById(Long id) {
+    public PostDetailResponseDto searchById(Long id) {
         Post findPost = postRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("게시글이 없습니다."));
 
-        return PostResponseDto.of(findPost);
+        return PostDetailResponseDto.builder()
+            .id(findPost.getId())
+            .title(findPost.getTitle())
+            .content(findPost.getContent())
+            .anonymity(findPost.isAnonymity())
+            .likeCount(findPost.getLikeCount())
+            .hateCount(findPost.getHateCount())
+            .build();
     }
 
-    public List<PostListResponseDto> searchPosts(Pageable pageable) {
+    public List<PostsResponseDto> searchPosts(Pageable pageable) {
         return postRepository.findAll(pageable)
             .stream()
-            .map(PostListResponseDto::of)
+            .map(post -> PostsResponseDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .anonymity(post.isAnonymity())
+                .likeCount(post.getLikeCount())
+                .hateCount(post.getHateCount())
+                .build())
             .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/fasttime/domain/member/controller/AdminControllerTest.java
+++ b/src/test/java/com/fasttime/domain/member/controller/AdminControllerTest.java
@@ -1,4 +1,5 @@
 package com.fasttime.domain.member.controller;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -6,17 +7,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasttime.domain.member.dto.MemberDto;
 import com.fasttime.domain.member.repository.MemberRepository;
-import com.fasttime.domain.member.service.AdminService;
 import com.fasttime.domain.member.service.MemberService;
 import com.fasttime.domain.post.dto.service.request.PostCreateServiceDto;
-import com.fasttime.domain.post.dto.service.response.PostResponseDto;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
-import com.fasttime.domain.post.entity.ReportStatus;
 import com.fasttime.domain.post.repository.PostRepository;
 import com.fasttime.domain.post.service.PostCommandService;
 import java.time.LocalDateTime;
 import javax.transaction.Transactional;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -59,8 +57,8 @@ public class AdminControllerTest {
                     "testTitle1", "testContent1", false);
             PostCreateServiceDto dto2 = new PostCreateServiceDto
                 (memberRepository.findByEmail("test").get().getId(), "testTitle2", "testContent2", false);
-            PostResponseDto postResponseDto1 = postCommandService.writePost(dto1);
-            PostResponseDto postResponseDto2 = postCommandService.writePost(dto2);
+            PostDetailResponseDto postResponseDto1 = postCommandService.writePost(dto1);
+            PostDetailResponseDto postResponseDto2 = postCommandService.writePost(dto2);
             Post post1 = postRepository.findById(postResponseDto1.getId()).get();
             Post post2 = postRepository.findById(postResponseDto2.getId()).get();
             post1.report();
@@ -83,8 +81,8 @@ public class AdminControllerTest {
             PostCreateServiceDto dto2 = new PostCreateServiceDto
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle2", "testContent2", false);
-            PostResponseDto postResponseDto1 = postCommandService.writePost(dto1);
-            PostResponseDto postResponseDto2 = postCommandService.writePost(dto2);
+            PostDetailResponseDto postResponseDto1 = postCommandService.writePost(dto1);
+            PostDetailResponseDto postResponseDto2 = postCommandService.writePost(dto2);
             Post post1 = postRepository.findById(postResponseDto1.getId()).get();
             Post post2 = postRepository.findById(postResponseDto2.getId()).get();
             // when, then
@@ -104,7 +102,7 @@ public class AdminControllerTest {
             PostCreateServiceDto dto1 = new PostCreateServiceDto
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
-            PostResponseDto postResponseDto1 = postCommandService.writePost(dto1);
+            PostDetailResponseDto postResponseDto1 = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(postResponseDto1.getId()).get();
             post1.report();
             post1.approveReport(LocalDateTime.now());
@@ -122,7 +120,7 @@ public class AdminControllerTest {
             PostCreateServiceDto dto1 = new PostCreateServiceDto
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
-            PostResponseDto postResponseDto1 = postCommandService.writePost(dto1);
+            PostDetailResponseDto postResponseDto1 = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(postResponseDto1.getId()).get();
             post1.report();
             post1.approveReport(LocalDateTime.now());
@@ -141,7 +139,7 @@ public class AdminControllerTest {
             PostCreateServiceDto dto1 = new PostCreateServiceDto
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
-            PostResponseDto postResponseDto1 = postCommandService.writePost(dto1);
+            PostDetailResponseDto postResponseDto1 = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(postResponseDto1.getId()).get();
             //when, then
             mockMvc.perform(get("/v1/admin/{post_id}",  post1.getId()))
@@ -158,7 +156,7 @@ public class AdminControllerTest {
             PostCreateServiceDto dto1 = new PostCreateServiceDto
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
-            PostResponseDto postResponseDto1 = postCommandService.writePost(dto1);
+            PostDetailResponseDto postResponseDto1 = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(postResponseDto1.getId()).get();
             post1.report();
             post1.approveReport(LocalDateTime.now());
@@ -176,7 +174,7 @@ public class AdminControllerTest {
             PostCreateServiceDto dto1 = new PostCreateServiceDto
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
-            PostResponseDto postResponseDto1 = postCommandService.writePost(dto1);
+            PostDetailResponseDto postResponseDto1 = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(postResponseDto1.getId()).get();
             post1.report();
             post1.approveReport(LocalDateTime.now());

--- a/src/test/java/com/fasttime/domain/member/service/AdminServiceTest.java
+++ b/src/test/java/com/fasttime/domain/member/service/AdminServiceTest.java
@@ -3,7 +3,7 @@ package com.fasttime.domain.member.service;
 import com.fasttime.domain.member.dto.MemberDto;
 import com.fasttime.domain.member.repository.MemberRepository;
 import com.fasttime.domain.post.dto.service.request.PostCreateServiceDto;
-import com.fasttime.domain.post.dto.service.response.PostResponseDto;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.entity.ReportStatus;
 import com.fasttime.domain.post.repository.PostRepository;
@@ -53,8 +53,8 @@ public class AdminServiceTest {
             PostCreateServiceDto dto2 = new PostCreateServiceDto
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle2", "testContent2", false);
-            PostResponseDto postResponseDto1 = postCommandService.writePost(dto1);
-            PostResponseDto postResponseDto2 = postCommandService.writePost(dto2);
+            PostDetailResponseDto postResponseDto1 = postCommandService.writePost(dto1);
+            PostDetailResponseDto postResponseDto2 = postCommandService.writePost(dto2);
             Post post1 = postRepository.findById(postResponseDto1.getId()).get();
             Post post2 = postRepository.findById(postResponseDto2.getId()).get();
             post1.report();
@@ -78,8 +78,8 @@ public class AdminServiceTest {
             PostCreateServiceDto dto2 = new PostCreateServiceDto
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle2", "testContent2", false);
-            PostResponseDto postResponseDto1 = postCommandService.writePost(dto1);
-            PostResponseDto postResponseDto2 = postCommandService.writePost(dto2);
+            PostDetailResponseDto postResponseDto1 = postCommandService.writePost(dto1);
+            PostDetailResponseDto postResponseDto2 = postCommandService.writePost(dto2);
             Post post1 = postRepository.findById(postResponseDto1.getId()).get();
             Post post2 = postRepository.findById(postResponseDto2.getId()).get();
             // when
@@ -98,7 +98,7 @@ public class AdminServiceTest {
             PostCreateServiceDto dto1 = new PostCreateServiceDto
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
-            PostResponseDto dto = postCommandService.writePost(dto1);
+            PostDetailResponseDto dto = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(dto.getId()).get();
             post1.report();
             post1.approveReport(LocalDateTime.now());
@@ -114,7 +114,7 @@ public class AdminServiceTest {
             PostCreateServiceDto dto1 = new PostCreateServiceDto
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
-            PostResponseDto postResponseDto1 = postCommandService.writePost(dto1);
+            PostDetailResponseDto postResponseDto1 = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(postResponseDto1.getId()).get();
             post1.report();
             post1.approveReport(LocalDateTime.now());
@@ -133,7 +133,7 @@ public class AdminServiceTest {
             PostCreateServiceDto dto1 = new PostCreateServiceDto
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
-            PostResponseDto postResponseDto1 = postCommandService.writePost(dto1);
+            PostDetailResponseDto postResponseDto1 = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(postResponseDto1.getId()).get();
             //when ,then
             Assertions.assertThatThrownBy(() -> adminService.PassPost(post1.getId()));
@@ -146,7 +146,7 @@ public class AdminServiceTest {
             PostCreateServiceDto dto1 = new PostCreateServiceDto
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
-            PostResponseDto postResponseDto1 = postCommandService.writePost(dto1);
+            PostDetailResponseDto postResponseDto1 = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(postResponseDto1.getId()).get();
             //when ,then
             Assertions.assertThatThrownBy(() -> adminService.PassPost(post1.getId()));

--- a/src/test/java/com/fasttime/domain/post/unit/controller/PostControllerUnitTest.java
+++ b/src/test/java/com/fasttime/domain/post/unit/controller/PostControllerUnitTest.java
@@ -1,0 +1,51 @@
+package com.fasttime.domain.post.unit.controller;
+
+import com.fasttime.utils.ControllerUnitTestContainer;
+
+class PostControllerUnitTest extends ControllerUnitTestContainer {
+
+//    @MockBean
+//    private PostCommandService postCommandService;
+//
+//    @WithMockUser
+//    @DisplayName("입력 양식을 정상적으로 입력받으면 정상적으로 프로세스가 진행된다.")
+//    @CsvSource({"1, title1, This is Content1, true", "2, title2, This is Content2, false"})
+//    @ParameterizedTest
+//    void allProperty_isOk_willPass(Long id, String title, String content, boolean isAnonymity)
+//        throws Exception {
+//        // given
+//        PostCreateRequestDto postCreateRequestDto = new PostCreateRequestDto(id, title, content,
+//            isAnonymity);
+//
+//        when(postCommandService.writePost(any(PostCreateServiceDto.class)))
+//            .thenReturn(PostDetailResponseDto.builder()
+//                .id(id)
+//                .title(title)
+//                .content(content)
+//                .anonymity(isAnonymity)
+//                .likeCount(0)
+//                .hateCount(0)
+//                .build());
+//
+//        // when then
+//        mockMvc.perform(post("/api/v1/post")
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .content(objectMapper.writeValueAsString(postCreateRequestDto)))
+//            .andDo(print())
+//            .andExpect(status().isCreated())
+//            .andExpect(jsonPath("$.id").value("201"))
+//            .andExpect(jsonPath("$.title").value(title))
+//            .andExpect(jsonPath("$.content").value(content))
+//            .andExpect(jsonPath("$.anonymity").value(isAnonymity))
+//            .andExpect(jsonPath("$.likeCount").value(0))
+//            .andExpect(jsonPath("$.hateCount").value(0));
+//    }
+//
+//    @DisplayName("writePost()는")
+//    @Nested
+//    class Context_writePost {
+//
+//    }
+
+
+}

--- a/src/test/java/com/fasttime/domain/post/unit/service/PostCommandServiceTest.java
+++ b/src/test/java/com/fasttime/domain/post/unit/service/PostCommandServiceTest.java
@@ -12,7 +12,7 @@ import com.fasttime.domain.member.repository.MemberRepository;
 import com.fasttime.domain.post.dto.service.request.PostCreateServiceDto;
 import com.fasttime.domain.post.dto.service.request.PostDeleteServiceDto;
 import com.fasttime.domain.post.dto.service.request.PostUpdateServiceDto;
-import com.fasttime.domain.post.dto.service.response.PostResponseDto;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.entity.ReportStatus;
 import com.fasttime.domain.post.exception.NotPostWriterException;
@@ -59,7 +59,7 @@ class PostCommandServiceTest {
             given(postRepository.save(any(Post.class))).willReturn(mockPost);
 
             // when
-            PostResponseDto response = postCommandService.writePost(dto);
+            PostDetailResponseDto response = postCommandService.writePost(dto);
 
             // then
             assertThat(response).extracting("id", "title", "content", "anonymity", "likeCount",
@@ -102,7 +102,7 @@ class PostCommandServiceTest {
             given(postRepository.findById(anyLong())).willReturn(Optional.of(mockPost));
 
             // when
-            PostResponseDto response = postCommandService.updatePost(serviceDto);
+            PostDetailResponseDto response = postCommandService.updatePost(serviceDto);
 
             // then
             assertThat(response).extracting("id", "title", "content", "anonymity", "likeCount",

--- a/src/test/java/com/fasttime/domain/post/unit/service/PostQueryServiceTest.java
+++ b/src/test/java/com/fasttime/domain/post/unit/service/PostQueryServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
-import com.fasttime.domain.post.dto.service.response.PostResponseDto;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.repository.PostRepository;
 import com.fasttime.domain.post.service.PostQueryService;
@@ -56,7 +56,7 @@ public class PostQueryServiceTest {
                     .build()));
 
             // when
-            PostResponseDto response = postQueryService.searchById(id);
+            PostDetailResponseDto response = postQueryService.searchById(id);
 
             // then
             assertThat(response)


### PR DESCRIPTION
Motivation:

- 현재 `PostListResponseDto.java`, `PostResponseDto.java`가 있었지만, PostList라는 네이밍이 List 타입의 Dto를 반환하는 것 처럼 느껴집니다. 이에 따라 Renaming이 필요해보입니다.

- Dto 각각 domain class를 받는 정적 팩토리 메서드 `xxxDto of(T t)`를 설계했었습니다. 하지만, 해당 도메인 뿐 아니라 다른 도메인들과 조합이 필요한 경우가 있기 때문에, 이를 제거하고 빌더패턴을 사용하기로 했습니다.

- 개발 전 `git pull`을 하지 않아 테스트 실패로 인해 재수정해서 PR.

Modification:

- `PostsResponseDto.java` 로 Renaming 하기로 결정했습니다. 이에 따라 `PostResponseDto.java`은 조금 더 명확하게 `PostDetailResponseDto.java` 로 변경하게 되었습니다.