### PR TITLE
[refactor] 게시글 API 들을 rest로 전환

### DIFF
--- a/src/main/java/com/fasttime/domain/post/controller/PostController.java
+++ b/src/main/java/com/fasttime/domain/post/controller/PostController.java
@@ -2,41 +2,73 @@ package com.fasttime.domain.post.controller;
 
 import com.fasttime.domain.post.dto.controller.request.PostCreateRequestDto;
 import com.fasttime.domain.post.dto.service.request.PostCreateServiceDto;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
+import com.fasttime.domain.post.dto.service.response.PostsResponseDto;
+import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.service.PostCommandService;
+import com.fasttime.domain.post.service.PostQueryService;
+import com.fasttime.global.util.ResponseDTO;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RequestMapping("/api/v1/post")
-@Controller
+@RestController
 public class PostController {
 
     private final PostCommandService postCommandService;
+    private final PostQueryService postQueryService;
 
-    public PostController(PostCommandService postCommandService) {
+    public PostController(PostCommandService postCommandService, PostQueryService postQueryService) {
         this.postCommandService = postCommandService;
+        this.postQueryService = postQueryService;
     }
 
-    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
-    public String writePost(@Valid @ModelAttribute PostCreateRequestDto requestDto,
-        Model model,
-        BindingResult bindingResult) {
-        log.info("request :" + requestDto);
-        postCommandService.writePost(
+    public ResponseEntity<ResponseDTO<PostDetailResponseDto>> writePost(
+        @RequestBody @Valid PostCreateRequestDto requestDto) {
+        Post result = postCommandService.writePost(
             new PostCreateServiceDto(requestDto.getMemberId(),
                 requestDto.getTitle(),
                 requestDto.getContent(),
                 requestDto.isAnonymity()));
 
-        return "post/posts";
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ResponseDTO.res(HttpStatus.CREATED, PostDetailResponseDto.entityToDto(result)));
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<ResponseDTO<PostDetailResponseDto>> getPost(@PathVariable long postId) {
+        Post result = postQueryService.findById(postId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ResponseDTO.res(HttpStatus.CREATED,
+                PostDetailResponseDto.entityToDto(result))
+            );
+    }
+
+    @GetMapping
+    public ResponseEntity<ResponseDTO<List<PostsResponseDto>>> getPosts(
+        @RequestParam(defaultValue = "") String title,
+        @RequestParam(defaultValue = "1") int page) {
+
+        List<PostsResponseDto> responses = postQueryService.findByPageForTitle(title, page)
+            .stream()
+            .map(PostsResponseDto::entityToDto)
+            .collect(Collectors.toList());
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ResponseDTO.res(HttpStatus.CREATED, responses));
     }
 }

--- a/src/main/java/com/fasttime/domain/post/dto/service/request/PostCreateServiceDto.java
+++ b/src/main/java/com/fasttime/domain/post/dto/service/request/PostCreateServiceDto.java
@@ -1,13 +1,21 @@
 package com.fasttime.domain.post.dto.service.request;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class PostCreateServiceDto {
 
+    @NotNull
     private final Long memberId;
+
+    @NotBlank
     private final String title;
+
+    @NotBlank
     private final String content;
+
     private final boolean anonymity;
 
     public PostCreateServiceDto(Long memberId, String title, String content, boolean anonymity) {

--- a/src/main/java/com/fasttime/domain/post/dto/service/response/PostDetailResponseDto.java
+++ b/src/main/java/com/fasttime/domain/post/dto/service/response/PostDetailResponseDto.java
@@ -1,5 +1,6 @@
 package com.fasttime.domain.post.dto.service.response;
 
+import com.fasttime.domain.post.entity.Post;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -22,5 +23,16 @@ public class PostDetailResponseDto {
         this.anonymity = anonymity;
         this.likeCount = likeCount;
         this.hateCount = hateCount;
+    }
+
+    public static PostDetailResponseDto entityToDto(Post post) {
+        return PostDetailResponseDto.builder()
+            .id(post.getId())
+            .title(post.getTitle())
+            .content(post.getContent())
+            .anonymity(post.isAnonymity())
+            .likeCount(post.getLikeCount())
+            .hateCount(post.getHateCount())
+            .build();
     }
 }

--- a/src/main/java/com/fasttime/domain/post/dto/service/response/PostsResponseDto.java
+++ b/src/main/java/com/fasttime/domain/post/dto/service/response/PostsResponseDto.java
@@ -1,5 +1,6 @@
 package com.fasttime.domain.post.dto.service.response;
 
+import com.fasttime.domain.post.entity.Post;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -22,5 +23,15 @@ public class PostsResponseDto {
         this.commentCounts = commentCounts;
         this.likeCount = likeCount;
         this.hateCount = hateCount;
+    }
+
+    public static PostsResponseDto entityToDto(Post post) {
+        return PostsResponseDto.builder()
+            .id(post.getId())
+            .title(post.getTitle())
+            .anonymity(post.isAnonymity())
+            .likeCount(post.getLikeCount())
+            .hateCount(post.getHateCount())
+            .build();
     }
 }

--- a/src/main/java/com/fasttime/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fasttime/domain/post/service/PostQueryService.java
@@ -1,6 +1,7 @@
 package com.fasttime.domain.post.service;
 
 import com.fasttime.domain.post.entity.Post;
+import com.fasttime.domain.post.exception.PostNotFoundException;
 import com.fasttime.domain.post.repository.PostRepository;
 import java.util.List;
 import org.springframework.data.domain.PageRequest;
@@ -22,7 +23,7 @@ public class PostQueryService implements PostQueryUseCase {
     @Override
     public Post findById(Long id) {
         return postRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("There is no Post which has id " + id));
+            .orElseThrow(PostNotFoundException::new);
     }
 
     @Override

--- a/src/test/java/com/fasttime/domain/post/unit/controller/PostControllerTest.java
+++ b/src/test/java/com/fasttime/domain/post/unit/controller/PostControllerTest.java
@@ -1,0 +1,54 @@
+package com.fasttime.domain.post.unit.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasttime.domain.post.dto.service.request.PostCreateServiceDto;
+import com.fasttime.util.ControllerUnitTestSupporter;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+@Disabled
+class PostControllerTest extends ControllerUnitTestSupporter {
+
+    @DisplayName("writePost(PostCreateRequestDto)는")
+    @Nested
+    class Context_WritePost {
+
+        @DisplayName("게시글을 저장할 수 있다.")
+        @Test
+        void post_willSave() throws Exception {
+
+            // given
+            PostCreateServiceDto requestDto = new PostCreateServiceDto(1L, "title",
+                "this is content", false);
+
+            // when then
+            mockMvc.perform(post("/api/v1/post")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                .andDo(print())
+                .andExpect(status().isCreated());
+        }
+
+        @DisplayName("회원 ID가 없는 경우 회원 관련 에러가 발생한다.")
+        @Test
+        void whenMemberId_isNull_willSend400Error() throws Exception {
+
+            // given
+            PostCreateServiceDto requestDto = new PostCreateServiceDto(null, "title",
+                "this is content", false);
+
+            // when then
+            mockMvc.perform(post("/api/v1/post")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/src/test/java/com/fasttime/domain/post/unit/service/PostQueryServiceTest.java
+++ b/src/test/java/com/fasttime/domain/post/unit/service/PostQueryServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.entity.ReportStatus;
+import com.fasttime.domain.post.exception.PostNotFoundException;
 import com.fasttime.domain.post.repository.PostRepository;
 import com.fasttime.domain.post.service.PostQueryService;
 import java.util.Optional;
@@ -76,7 +77,7 @@ public class PostQueryServiceTest {
 
             // when then
             assertThatThrownBy(() -> postQueryService.findById(1L))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(PostNotFoundException.class);
         }
     }
 }

--- a/src/test/java/com/fasttime/util/ControllerUnitTestSupporter.java
+++ b/src/test/java/com/fasttime/util/ControllerUnitTestSupporter.java
@@ -1,0 +1,35 @@
+package com.fasttime.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasttime.domain.post.controller.PostController;
+import com.fasttime.domain.post.service.PostCommandService;
+import com.fasttime.domain.post.service.PostQueryService;
+import org.apache.catalina.security.SecurityConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(value = PostController.class,
+    excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)},
+    excludeAutoConfiguration = SecurityAutoConfiguration.class)
+public abstract class ControllerUnitTestSupporter {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockBean
+    protected PostCommandService postCommandService;
+
+    @MockBean
+    protected PostQueryService postQueryService;
+
+
+}


### PR DESCRIPTION
Motivation:
- 이제 Template-Engine이 아닌 Frontend 서버를 따로 운용하기 떄문에 Rest-API 로 전환합니다.

Modification:
- `Controller` -> `RestController` 으로 전환
- 테스트 코드 수정