### PR TITLE
[feat] 게시글 댓글 조회 API 구현

### DIFF
--- a/src/main/java/com/fasttime/domain/comment/controller/CommentRestController.java
+++ b/src/main/java/com/fasttime/domain/comment/controller/CommentRestController.java
@@ -12,7 +12,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,7 +29,7 @@ public class CommentRestController {
 
     private final CommentService commentService;
 
-    @PostMapping("/create")
+    @PostMapping
     public ResponseEntity<ResponseDTO<CommentDTO>> create(
         @Valid @RequestBody CreateCommentRequest createCommentRequest) {
         log.info("CreateCommentRequest: " + createCommentRequest);
@@ -37,15 +39,24 @@ public class CommentRestController {
     }
 
     @GetMapping("/my-page/{memberId}")
-    public ResponseEntity<ResponseDTO<List<CommentDTO>>> getCommentByMemberId(
+    public ResponseEntity<ResponseDTO<List<CommentDTO>>> getCommentsByMemberId(
         @PathVariable long memberId) {
-        log.info("getCommentByMemberId: " + memberId);
+        log.info("getCommentsByMemberId: " + memberId);
         return ResponseEntity.status(HttpStatus.OK).body(
             ResponseDTO.res(HttpStatus.OK, "댓글을 성공적으로 조회했습니다.",
-                commentService.getCommentByMemberId(memberId)));
+                commentService.getCommentsByMemberId(memberId)));
     }
 
-    @PostMapping("/update")
+    @GetMapping("/{postId}")
+    public ResponseEntity<ResponseDTO<List<CommentDTO>>> getCommentsByPostId(
+        @PathVariable long postId) {
+        log.info("getCommentsByPostId: " + postId);
+        return ResponseEntity.status(HttpStatus.OK).body(
+            ResponseDTO.res(HttpStatus.OK, "댓글을 성공적으로 조회했습니다.",
+                commentService.getCommentsByPostId(postId)));
+    }
+
+    @PatchMapping
     public ResponseEntity<ResponseDTO<CommentDTO>> update(
         @Valid @RequestBody UpdateCommentRequest updateCommentRequest) {
         log.info("UpdateCommentRequest: " + updateCommentRequest);
@@ -54,7 +65,7 @@ public class CommentRestController {
                 commentService.updateComment(updateCommentRequest)));
     }
 
-    @PostMapping("/delete")
+    @DeleteMapping
     public ResponseEntity<ResponseDTO<CommentDTO>> delete(
         @Valid @RequestBody DeleteCommentRequest deleteCommentRequest) {
         log.info("DeleteCommentRequest: " + deleteCommentRequest);

--- a/src/main/java/com/fasttime/domain/comment/controller/CommentRestController.java
+++ b/src/main/java/com/fasttime/domain/comment/controller/CommentRestController.java
@@ -30,7 +30,7 @@ public class CommentRestController {
     private final CommentService commentService;
 
     @PostMapping
-    public ResponseEntity<ResponseDTO<CommentDTO>> create(
+    public ResponseEntity<ResponseDTO<CommentDTO>> createComment(
         @Valid @RequestBody CreateCommentRequest createCommentRequest) {
         log.info("CreateCommentRequest: " + createCommentRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(
@@ -57,7 +57,7 @@ public class CommentRestController {
     }
 
     @PatchMapping
-    public ResponseEntity<ResponseDTO<CommentDTO>> update(
+    public ResponseEntity<ResponseDTO<CommentDTO>> updateComment(
         @Valid @RequestBody UpdateCommentRequest updateCommentRequest) {
         log.info("UpdateCommentRequest: " + updateCommentRequest);
         return ResponseEntity.status(HttpStatus.OK).body(
@@ -66,7 +66,7 @@ public class CommentRestController {
     }
 
     @DeleteMapping
-    public ResponseEntity<ResponseDTO<CommentDTO>> delete(
+    public ResponseEntity<ResponseDTO<CommentDTO>> deleteComment(
         @Valid @RequestBody DeleteCommentRequest deleteCommentRequest) {
         log.info("DeleteCommentRequest: " + deleteCommentRequest);
         return ResponseEntity.status(HttpStatus.OK).body(

--- a/src/test/java/com/fasttime/domain/comment/controller/CommentRestControllerTest.java
+++ b/src/test/java/com/fasttime/domain/comment/controller/CommentRestControllerTest.java
@@ -40,8 +40,8 @@ public class CommentRestControllerTest {
     CommentService commentService;
 
     @Nested
-    @DisplayName("create()은")
-    class Context_create {
+    @DisplayName("createComment()은")
+    class Context_createComment {
 
         @Test
         @DisplayName("댓글을 등록할 수 있다.")
@@ -195,8 +195,8 @@ public class CommentRestControllerTest {
     }
 
     @Nested
-    @DisplayName("getCommentByMemberId()은 ")
-    class Context_getCommentByMemberId {
+    @DisplayName("getCommentsByMemberId()은 ")
+    class Context_getCommentsByMemberId {
 
         @Test
         @DisplayName("해당 회원의 댓글을 조회할 수 있다.")
@@ -222,7 +222,7 @@ public class CommentRestControllerTest {
     }
 
     @Nested
-    @DisplayName("getCommentByPostId()은 ")
+    @DisplayName("getCommentsByPostId()은 ")
     class Context_getCommentByPostId {
 
         @Test
@@ -249,8 +249,8 @@ public class CommentRestControllerTest {
     }
 
     @Nested
-    @DisplayName("update()는 ")
-    class Context_update {
+    @DisplayName("updateComment()는 ")
+    class Context_updateComment {
 
         @Test
         @DisplayName("댓글을 수정할 수 있다.")
@@ -352,8 +352,8 @@ public class CommentRestControllerTest {
     }
 
     @Nested
-    @DisplayName("delete()은 ")
-    class Context_delete {
+    @DisplayName("deleteComment()은 ")
+    class Context_deleteComment {
 
         @Test
         @DisplayName("댓글을 삭제할 수 있다.")

--- a/src/test/java/com/fasttime/domain/comment/controller/CommentRestControllerTest.java
+++ b/src/test/java/com/fasttime/domain/comment/controller/CommentRestControllerTest.java
@@ -5,7 +5,9 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -54,9 +56,9 @@ public class CommentRestControllerTest {
             String json = new ObjectMapper().writeValueAsString(request);
 
             // when, then
-            mockMvc.perform(post("/api/v1/comment/create").content(json)
-                    .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isCreated())
-                .andExpect(jsonPath("$.data.id").exists())
+            mockMvc.perform(
+                    post("/api/v1/comment").content(json).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated()).andExpect(jsonPath("$.data.id").exists())
                 .andExpect(jsonPath("$.data.postId").exists())
                 .andExpect(jsonPath("$.data.memberId").exists())
                 .andExpect(jsonPath("$.data.content").exists())
@@ -83,9 +85,10 @@ public class CommentRestControllerTest {
                 String json = new ObjectMapper().writeValueAsString(request);
 
                 // when, then
-                mockMvc.perform(post("/api/v1/comment/create").content(json)
-                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+                mockMvc.perform(
+                        post("/api/v1/comment").content(json).contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message").exists())
+                    .andDo(print());
 
                 verify(commentService, never()).createComment(any(CreateCommentRequest.class));
             }
@@ -108,9 +111,10 @@ public class CommentRestControllerTest {
                 String json = new ObjectMapper().writeValueAsString(request);
 
                 // when, then
-                mockMvc.perform(post("/api/v1/comment/create").content(json)
-                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+                mockMvc.perform(
+                        post("/api/v1/comment").content(json).contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message").exists())
+                    .andDo(print());
 
                 verify(commentService, never()).createComment(any(CreateCommentRequest.class));
             }
@@ -133,9 +137,10 @@ public class CommentRestControllerTest {
                 String json = new ObjectMapper().writeValueAsString(request);
 
                 // whCreate
-                mockMvc.perform(post("/api/v1/comment/create").content(json)
-                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+                mockMvc.perform(
+                        post("/api/v1/comment").content(json).contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message").exists())
+                    .andDo(print());
 
                 verify(commentService, never()).createComment(any(CreateCommentRequest.class));
             }
@@ -153,9 +158,10 @@ public class CommentRestControllerTest {
                 String json = new ObjectMapper().writeValueAsString(request);
 
                 // when, then
-                mockMvc.perform(post("/api/v1/comment/create").content(json)
-                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+                mockMvc.perform(
+                        post("/api/v1/comment").content(json).contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message").exists())
+                    .andDo(print());
 
                 verify(commentService, never()).createComment(any(CreateCommentRequest.class));
             }
@@ -178,9 +184,10 @@ public class CommentRestControllerTest {
                 String json = new ObjectMapper().writeValueAsString(request);
 
                 // when, then
-                mockMvc.perform(post("/api/v1/comment/create").content(json)
-                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+                mockMvc.perform(
+                        post("/api/v1/comment").content(json).contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message").exists())
+                    .andDo(print());
 
                 verify(commentService, never()).createComment(any(CreateCommentRequest.class));
             }
@@ -199,7 +206,7 @@ public class CommentRestControllerTest {
             commentDTOList.add(
                 CommentDTO.builder().id(0L).postId(0L).memberId(0L).content("test").anonymity(false)
                     .parentCommentId(null).build());
-            given(commentService.getCommentByMemberId(any(long.class))).willReturn(commentDTOList);
+            given(commentService.getCommentsByMemberId(any(long.class))).willReturn(commentDTOList);
 
             // when, then
             mockMvc.perform(get("/api/v1/comment/my-page/0")).andExpect(status().isOk())
@@ -210,7 +217,34 @@ public class CommentRestControllerTest {
                 .andExpect(jsonPath("$.data[0].anonymity").exists())
                 .andExpect(jsonPath("$.data[0].parentCommentId").isEmpty()).andDo(print());
 
-            verify(commentService, times(1)).getCommentByMemberId(any(long.class));
+            verify(commentService, times(1)).getCommentsByMemberId(any(long.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("getCommentByPostId()은 ")
+    class Context_getCommentByPostId {
+
+        @Test
+        @DisplayName("해당 게시물의 댓글을 조회할 수 있다.")
+        void _willSuccess() throws Exception {
+            // given
+            List<CommentDTO> commentDTOList = new ArrayList<>();
+            commentDTOList.add(
+                CommentDTO.builder().id(0L).postId(0L).memberId(0L).content("test").anonymity(false)
+                    .parentCommentId(null).build());
+            given(commentService.getCommentsByPostId(any(long.class))).willReturn(commentDTOList);
+
+            // when, then
+            mockMvc.perform(get("/api/v1/comment/0")).andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].id").exists())
+                .andExpect(jsonPath("$.data[0].postId").exists())
+                .andExpect(jsonPath("$.data[0].memberId").exists())
+                .andExpect(jsonPath("$.data[0].content").exists())
+                .andExpect(jsonPath("$.data[0].anonymity").exists())
+                .andExpect(jsonPath("$.data[0].parentCommentId").isEmpty()).andDo(print());
+
+            verify(commentService, times(1)).getCommentsByPostId(any(long.class));
         }
     }
 
@@ -231,9 +265,9 @@ public class CommentRestControllerTest {
             String json = new ObjectMapper().writeValueAsString(request);
 
             // when, then
-            mockMvc.perform(post("/api/v1/comment/update").content(json)
-                    .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id").exists())
+            mockMvc.perform(
+                    patch("/api/v1/comment").content(json).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.data.id").exists())
                 .andExpect(jsonPath("$.data.postId").exists())
                 .andExpect(jsonPath("$.data.memberId").exists())
                 .andExpect(jsonPath("$.data.content").exists())
@@ -260,9 +294,10 @@ public class CommentRestControllerTest {
                 String json = new ObjectMapper().writeValueAsString(request);
 
                 // when, then
-                mockMvc.perform(post("/api/v1/comment/update").content(json)
-                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+                mockMvc.perform(
+                        patch("/api/v1/comment").content(json).contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message").exists())
+                    .andDo(print());
 
                 verify(commentService, never()).updateComment(any(UpdateCommentRequest.class));
             }
@@ -285,9 +320,10 @@ public class CommentRestControllerTest {
                 String json = new ObjectMapper().writeValueAsString(request);
 
                 // when, then
-                mockMvc.perform(post("/api/v1/comment/update").content(json)
-                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+                mockMvc.perform(
+                        patch("/api/v1/comment").content(json).contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message").exists())
+                    .andDo(print());
 
                 verify(commentService, never()).updateComment(any(UpdateCommentRequest.class));
             }
@@ -305,9 +341,10 @@ public class CommentRestControllerTest {
                 String json = new ObjectMapper().writeValueAsString(request);
 
                 // when, then
-                mockMvc.perform(post("/api/v1/comment/update").content(json)
-                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+                mockMvc.perform(
+                        patch("/api/v1/comment").content(json).contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message").exists())
+                    .andDo(print());
 
                 verify(commentService, never()).updateComment(any(UpdateCommentRequest.class));
             }
@@ -330,9 +367,9 @@ public class CommentRestControllerTest {
             String json = new ObjectMapper().writeValueAsString(request);
 
             // when, then
-            mockMvc.perform(post("/api/v1/comment/delete").content(json)
-                    .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id").exists())
+            mockMvc.perform(
+                    delete("/api/v1/comment").content(json).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.data.id").exists())
                 .andExpect(jsonPath("$.data.postId").exists())
                 .andExpect(jsonPath("$.data.memberId").exists())
                 .andExpect(jsonPath("$.data.content").exists())
@@ -358,9 +395,10 @@ public class CommentRestControllerTest {
                 String json = new ObjectMapper().writeValueAsString(request);
 
                 // when, then
-                mockMvc.perform(post("/api/v1/comment/delete").content(json)
-                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+                mockMvc.perform(
+                        delete("/api/v1/comment").content(json).contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message").exists())
+                    .andDo(print());
 
                 verify(commentService, never()).deleteComment(any(DeleteCommentRequest.class));
             }

--- a/src/test/java/com/fasttime/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/fasttime/domain/comment/service/CommentServiceTest.java
@@ -21,7 +21,7 @@ import com.fasttime.domain.member.exception.UserNotFoundException;
 import com.fasttime.domain.member.service.MemberService;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.exception.PostNotFoundException;
-import com.fasttime.domain.post.repository.PostRepository;
+import com.fasttime.domain.post.service.PostQueryService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -45,7 +45,7 @@ public class CommentServiceTest {
     private CommentRepository commentRepository;
 
     @Mock
-    private PostRepository postRepository;
+    private PostQueryService postQueryService;
 
     @Mock
     private MemberService memberService;
@@ -60,12 +60,12 @@ public class CommentServiceTest {
             // given
             CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
                 .content("test").anonymity(false).parentCommentId(null).build();
-            Optional<Post> post = Optional.of(Post.builder().id(0L).build());
+            Post post = Post.builder().id(0L).build();
             Member member = Member.builder().id(0L).build();
-            Comment comment = Comment.builder().id(0L).post(post.get()).member(member)
-                .content("test").anonymity(false).parentComment(null).build();
+            Comment comment = Comment.builder().id(0L).post(post).member(member).content("test")
+                .anonymity(false).parentComment(null).build();
 
-            given(postRepository.findById(any(Long.class))).willReturn(post);
+            given(postQueryService.findById(any(Long.class))).willReturn(post);
             given(memberService.getMember(any(Long.class))).willReturn(member);
             given(commentRepository.save(any(Comment.class))).willReturn(comment);
 
@@ -76,7 +76,7 @@ public class CommentServiceTest {
             assertThat(CommentDto).extracting("id", "postId", "memberId", "content", "anonymity",
                 "parentCommentId").containsExactly(0L, 0L, 0L, "test", false, null);
 
-            verify(postRepository, times(1)).findById(any(Long.class));
+            verify(postQueryService, times(1)).findById(any(Long.class));
             verify(memberService, times(1)).getMember(any(Long.class));
             verify(commentRepository, never()).findById(any(Long.class));
             verify(commentRepository, times(1)).save(any(Comment.class));
@@ -88,12 +88,12 @@ public class CommentServiceTest {
             // given
             CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
                 .content("test").anonymity(true).parentCommentId(null).build();
-            Optional<Post> post = Optional.of(Post.builder().id(0L).build());
+            Post post = Post.builder().id(0L).build();
             Member member = Member.builder().id(0L).build();
-            Comment comment = Comment.builder().id(0L).post(post.get()).member(member)
-                .content("test").anonymity(true).parentComment(null).build();
+            Comment comment = Comment.builder().id(0L).post(post).member(member).content("test")
+                .anonymity(true).parentComment(null).build();
 
-            given(postRepository.findById(any(Long.class))).willReturn(post);
+            given(postQueryService.findById(any(Long.class))).willReturn(post);
             given(memberService.getMember(any(Long.class))).willReturn(member);
             given(commentRepository.save(any(Comment.class))).willReturn(comment);
 
@@ -104,7 +104,7 @@ public class CommentServiceTest {
             assertThat(CommentDto).extracting("id", "postId", "memberId", "content", "anonymity",
                 "parentCommentId").containsExactly(0L, 0L, 0L, "test", true, null);
 
-            verify(postRepository, times(1)).findById(any(Long.class));
+            verify(postQueryService, times(1)).findById(any(Long.class));
             verify(memberService, times(1)).getMember(any(Long.class));
             verify(commentRepository, never()).findById(any(Long.class));
             verify(commentRepository, times(1)).save(any(Comment.class));
@@ -116,16 +116,16 @@ public class CommentServiceTest {
             // given
             CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
                 .content("test").anonymity(false).parentCommentId(0L).build();
-            Optional<Post> post = Optional.of(Post.builder().id(0L).build());
+            Post post = Post.builder().id(0L).build();
             Member member = Member.builder().id(0L).build();
             Optional<Comment> parentComment = Optional.of(
-                Comment.builder().id(0L).post(post.get()).member(member).content("test")
-                    .anonymity(false).parentComment(null).build());
-            Comment comment = Comment.builder().id(1L).post(post.get()).member(member)
-                .content("test").anonymity(false).parentComment(parentComment.get()).build();
+                Comment.builder().id(0L).post(post).member(member).content("test").anonymity(false)
+                    .parentComment(null).build());
+            Comment comment = Comment.builder().id(1L).post(post).member(member).content("test")
+                .anonymity(false).parentComment(parentComment.get()).build();
 
             given(commentRepository.findById(any(Long.class))).willReturn(parentComment);
-            given(postRepository.findById(any(Long.class))).willReturn(post);
+            given(postQueryService.findById(any(Long.class))).willReturn(post);
             given(memberService.getMember(any(Long.class))).willReturn(member);
             given(commentRepository.save(any(Comment.class))).willReturn(comment);
             // when
@@ -135,7 +135,7 @@ public class CommentServiceTest {
             assertThat(CommentDto).extracting("id", "postId", "memberId", "content", "anonymity",
                 "parentCommentId").containsExactly(1L, 0L, 0L, "test", false, 0L);
 
-            verify(postRepository, times(1)).findById(any(Long.class));
+            verify(postQueryService, times(1)).findById(any(Long.class));
             verify(memberService, times(1)).getMember(any(Long.class));
             verify(commentRepository, times(1)).findById(any(Long.class));
             verify(commentRepository, times(1)).save(any(Comment.class));
@@ -147,16 +147,16 @@ public class CommentServiceTest {
             // given
             CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
                 .content("test").anonymity(true).parentCommentId(0L).build();
-            Optional<Post> post = Optional.of(Post.builder().id(0L).build());
+            Post post = Post.builder().id(0L).build();
             Member member = Member.builder().id(0L).build();
             Optional<Comment> parentComment = Optional.of(
-                Comment.builder().id(0L).post(post.get()).member(member).content("test")
-                    .anonymity(false).parentComment(null).build());
-            Comment comment = Comment.builder().id(1L).post(post.get()).member(member)
-                .content("test").anonymity(true).parentComment(parentComment.get()).build();
+                Comment.builder().id(0L).post(post).member(member).content("test").anonymity(false)
+                    .parentComment(null).build());
+            Comment comment = Comment.builder().id(1L).post(post).member(member).content("test")
+                .anonymity(true).parentComment(parentComment.get()).build();
 
             given(commentRepository.findById(any(Long.class))).willReturn(parentComment);
-            given(postRepository.findById(any(Long.class))).willReturn(post);
+            given(postQueryService.findById(any(Long.class))).willReturn(post);
             given(memberService.getMember(any(Long.class))).willReturn(member);
             given(commentRepository.save(any(Comment.class))).willReturn(comment);
 
@@ -167,7 +167,7 @@ public class CommentServiceTest {
             assertThat(CommentDto).extracting("id", "postId", "memberId", "content", "anonymity",
                 "parentCommentId").containsExactly(1L, 0L, 0L, "test", true, 0L);
 
-            verify(postRepository, times(1)).findById(any(Long.class));
+            verify(postQueryService, times(1)).findById(any(Long.class));
             verify(memberService, times(1)).getMember(any(Long.class));
             verify(commentRepository, times(1)).findById(any(Long.class));
             verify(commentRepository, times(1)).save(any(Comment.class));
@@ -179,9 +179,9 @@ public class CommentServiceTest {
             // given
             CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
                 .content("test").anonymity(false).parentCommentId(null).build();
-            Optional<Post> post = Optional.empty();
 
-            given(postRepository.findById(any(Long.class))).willReturn(post);
+            given(postQueryService.findById(any(Long.class))).willThrow(
+                new PostNotFoundException());
 
             // when, then
             Throwable exception = assertThrows(PostNotFoundException.class, () -> {
@@ -199,8 +199,8 @@ public class CommentServiceTest {
             // given
             CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
                 .content("test").anonymity(false).parentCommentId(null).build();
-            Optional<Post> post = Optional.of(Post.builder().id(0L).build());
-            given(postRepository.findById(any(Long.class))).willReturn(post);
+            Post post = Post.builder().id(0L).build();
+            given(postQueryService.findById(any(Long.class))).willReturn(post);
             given(memberService.getMember(any(Long.class))).willThrow(
                 new UserNotFoundException("User not found with id: 0L"));
 
@@ -210,7 +210,7 @@ public class CommentServiceTest {
             });
             assertEquals("User not found with id: 0L", exception.getMessage());
 
-            verify(postRepository, times(1)).findById(any(Long.class));
+            verify(postQueryService, times(1)).findById(any(Long.class));
             verify(memberService, times(1)).getMember(any(Long.class));
             verify(commentRepository, never()).findById(any(Long.class));
             verify(commentRepository, never()).save(any(Comment.class));
@@ -399,7 +399,8 @@ public class CommentServiceTest {
 
             // then
             assertThat(result.get(0).getId()).isEqualTo(commentDTOList.get(0).getId());
-            assertThat(result.get(0).getContent().equals(commentDTOList.get(0).getContent())).isTrue();
+            assertThat(
+                result.get(0).getContent().equals(commentDTOList.get(0).getContent())).isTrue();
 
             verify(commentRepository, times(1)).findAllByPost(any(Post.class));
         }
@@ -445,13 +446,13 @@ public class CommentServiceTest {
 
             given(commentRepository.findAllByMember(any(Member.class))).willReturn(comments);
 
-
             // when
             List<CommentDTO> result = commentService.getCommentsByMember(member);
 
             // then
             assertThat(result.get(0).getId()).isEqualTo(commentDTOList.get(0).getId());
-            assertThat(result.get(0).getContent().equals(commentDTOList.get(0).getContent())).isTrue();
+            assertThat(
+                result.get(0).getContent().equals(commentDTOList.get(0).getContent())).isTrue();
 
             verify(commentRepository, times(1)).findAllByMember(any(Member.class));
         }


### PR DESCRIPTION
게시글에서 댓글을 조회할 수 있도록 API를 추가 구현했습니다. 

## 개발 내용
- 추가할 기능 TEST 작성
- 게시글 ID로 댓글 조회 기능 추가
- 게시글에서  댓글 API 추가
  - 댓글 API 메서드 변경 (DELETE, PATCH 사용)
- 추가한 API TEST 작성
- 메서드명 리팩토링
