### PR TITLE
[refactor] PostQueryService API 수정

### DIFF
--- a/src/main/java/com/fasttime/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fasttime/domain/comment/service/CommentService.java
@@ -10,6 +10,7 @@ import com.fasttime.domain.comment.exception.CommentNotFoundException;
 import com.fasttime.domain.comment.repository.CommentRepository;
 import com.fasttime.domain.member.entity.Member;
 import com.fasttime.domain.member.service.MemberService;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.service.PostQueryService;
 import java.util.ArrayList;
@@ -39,8 +40,11 @@ public class CommentService {
         if (req.getParentCommentId() != null) {
             parentComment = getComment(req.getParentCommentId());
         }
+
+        PostDetailResponseDto postResponse = postQueryService.findById(req.getPostId());
+
         return commentRepository.save(
-                Comment.builder().post(postQueryService.findById(req.getPostId()))
+                Comment.builder().post(Post.builder().id(postResponse.getId()).build())
                     .member(memberService.getMember(req.getMemberId())).content(req.getContent())
                     .anonymity(req.getAnonymity()).parentComment(parentComment).build())
             .toPostCommentResponseDTO();
@@ -63,7 +67,8 @@ public class CommentService {
      * @return 게시글에 등록된 댓글 DTO 리스트
      */
     public List<PostCommentResponseDTO> getCommentsByPostId(long postId) {
-        return getCommentsByPost(postQueryService.findById(postId));
+        PostDetailResponseDto postResponse = postQueryService.findById(postId);
+        return getCommentsByPost(Post.builder().id(postResponse.getId()).build());
     }
 
     /**

--- a/src/main/java/com/fasttime/domain/post/controller/PostController.java
+++ b/src/main/java/com/fasttime/domain/post/controller/PostController.java
@@ -8,7 +8,6 @@ import com.fasttime.domain.post.dto.service.request.PostDeleteServiceDto;
 import com.fasttime.domain.post.dto.service.request.PostUpdateServiceDto;
 import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.dto.service.response.PostsResponseDto;
-import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.service.PostCommandUseCase;
 import com.fasttime.domain.post.service.PostQueryUseCase;
 import com.fasttime.domain.post.service.PostQueryUseCase.PostSearchCondition;
@@ -46,14 +45,13 @@ public class PostController {
     @PostMapping
     public ResponseEntity<ResponseDTO<PostDetailResponseDto>> writePost(
         @RequestBody @Valid PostCreateRequestDto requestDto) {
-        Post result = postCommandUseCase.writePost(
-            new PostCreateServiceDto(requestDto.getMemberId(),
-                requestDto.getTitle(),
-                requestDto.getContent(),
-                requestDto.isAnonymity()));
 
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(ResponseDTO.res(HttpStatus.CREATED, PostDetailResponseDto.entityToDto(result)));
+            .body(ResponseDTO.res(HttpStatus.CREATED, postCommandUseCase.writePost(
+                new PostCreateServiceDto(requestDto.getMemberId(),
+                    requestDto.getTitle(),
+                    requestDto.getContent(),
+                    requestDto.isAnonymity()))));
     }
 
     @PatchMapping
@@ -85,11 +83,10 @@ public class PostController {
 
     @GetMapping("/{postId}")
     public ResponseEntity<ResponseDTO<PostDetailResponseDto>> getPost(@PathVariable long postId) {
-        Post result = postQueryUseCase.findById(postId);
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(ResponseDTO.res(HttpStatus.OK,
-                PostDetailResponseDto.entityToDto(result)));
+                postQueryUseCase.findById(postId)));
     }
 
     @GetMapping

--- a/src/main/java/com/fasttime/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fasttime/domain/post/service/PostQueryService.java
@@ -1,7 +1,7 @@
 package com.fasttime.domain.post.service;
 
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.dto.service.response.PostsResponseDto;
-import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.exception.PostNotFoundException;
 import com.fasttime.domain.post.repository.PostRepository;
 import java.util.List;
@@ -20,9 +20,9 @@ public class PostQueryService implements PostQueryUseCase {
     }
 
     @Override
-    public Post findById(Long id) {
-        return postRepository.findById(id)
-            .orElseThrow(PostNotFoundException::new);
+    public PostDetailResponseDto findById(Long id) {
+        return PostDetailResponseDto.entityToDto(postRepository.findById(id)
+            .orElseThrow(PostNotFoundException::new));
     }
 
     @Override
@@ -36,6 +36,8 @@ public class PostQueryService implements PostQueryUseCase {
                 .anonymity(repositoryDto.isAnonymity())
                 .likeCount(repositoryDto.getLikeCount())
                 .hateCount(repositoryDto.getHateCount())
+                .createdAt(repositoryDto.getCreatedAt())
+                .createdAt(repositoryDto.getLastModifiedAt())
                 .build())
             .collect(Collectors.toList());
     }

--- a/src/main/java/com/fasttime/domain/post/service/PostQueryUseCase.java
+++ b/src/main/java/com/fasttime/domain/post/service/PostQueryUseCase.java
@@ -1,14 +1,14 @@
 package com.fasttime.domain.post.service;
 
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.dto.service.response.PostsResponseDto;
-import com.fasttime.domain.post.entity.Post;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
 public interface PostQueryUseCase {
 
-    Post findById(Long id);
+    PostDetailResponseDto findById(Long id);
 
     List<PostsResponseDto> searchPost(PostSearchCondition postSearchCondition);
 

--- a/src/test/java/com/fasttime/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/fasttime/domain/comment/service/CommentServiceTest.java
@@ -20,6 +20,7 @@ import com.fasttime.domain.comment.repository.CommentRepository;
 import com.fasttime.domain.member.entity.Member;
 import com.fasttime.domain.member.exception.UserNotFoundException;
 import com.fasttime.domain.member.service.MemberService;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.exception.PostNotFoundException;
 import com.fasttime.domain.post.service.PostQueryService;
@@ -61,12 +62,11 @@ public class CommentServiceTest {
             // given
             CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
                 .content("test").anonymity(false).parentCommentId(null).build();
-            Post post = Post.builder().id(0L).build();
             Member member = Member.builder().id(0L).nickname("testNickname").build();
-            Comment comment = Comment.builder().id(0L).post(post).member(member).content("test")
+            Comment comment = Comment.builder().id(0L).post(Post.builder().id(0L).build()).member(member).content("test")
                 .anonymity(false).parentComment(null).build();
 
-            given(postQueryService.findById(any(Long.class))).willReturn(post);
+            given(postQueryService.findById(any(Long.class))).willReturn(PostDetailResponseDto.builder().id(0L).build());
             given(memberService.getMember(any(Long.class))).willReturn(member);
             given(commentRepository.save(any(Comment.class))).willReturn(comment);
 
@@ -95,7 +95,7 @@ public class CommentServiceTest {
             Comment comment = Comment.builder().id(0L).post(post).member(member).content("test")
                 .anonymity(true).parentComment(null).build();
 
-            given(postQueryService.findById(any(Long.class))).willReturn(post);
+            given(postQueryService.findById(any(Long.class))).willReturn(PostDetailResponseDto.builder().id(0L).build());
             given(memberService.getMember(any(Long.class))).willReturn(member);
             given(commentRepository.save(any(Comment.class))).willReturn(comment);
 
@@ -128,7 +128,7 @@ public class CommentServiceTest {
                 .anonymity(false).parentComment(parentComment.get()).build();
 
             given(commentRepository.findById(any(Long.class))).willReturn(parentComment);
-            given(postQueryService.findById(any(Long.class))).willReturn(post);
+            given(postQueryService.findById(any(Long.class))).willReturn(PostDetailResponseDto.builder().id(0L).build());
             given(memberService.getMember(any(Long.class))).willReturn(member);
             given(commentRepository.save(any(Comment.class))).willReturn(comment);
             // when
@@ -160,7 +160,7 @@ public class CommentServiceTest {
                 .anonymity(true).parentComment(parentComment.get()).build();
 
             given(commentRepository.findById(any(Long.class))).willReturn(parentComment);
-            given(postQueryService.findById(any(Long.class))).willReturn(post);
+            given(postQueryService.findById(any(Long.class))).willReturn(PostDetailResponseDto.builder().id(0L).build());
             given(memberService.getMember(any(Long.class))).willReturn(member);
             given(commentRepository.save(any(Comment.class))).willReturn(comment);
 
@@ -205,7 +205,7 @@ public class CommentServiceTest {
             CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
                 .content("test").anonymity(false).parentCommentId(null).build();
             Post post = Post.builder().id(0L).build();
-            given(postQueryService.findById(any(Long.class))).willReturn(post);
+            given(postQueryService.findById(any(Long.class))).willReturn(PostDetailResponseDto.builder().id(0L).build());
             given(memberService.getMember(any(Long.class))).willThrow(
                 new UserNotFoundException("User not found with id: 0L"));
 

--- a/src/test/java/com/fasttime/domain/member/controller/AdminControllerTest.java
+++ b/src/test/java/com/fasttime/domain/member/controller/AdminControllerTest.java
@@ -9,6 +9,7 @@ import com.fasttime.domain.member.dto.MemberDto;
 import com.fasttime.domain.member.repository.MemberRepository;
 import com.fasttime.domain.member.service.MemberService;
 import com.fasttime.domain.post.dto.service.request.PostCreateServiceDto;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.repository.PostRepository;
 import com.fasttime.domain.post.service.PostCommandService;
@@ -57,8 +58,8 @@ public class AdminControllerTest {
             PostCreateServiceDto dto2 = new PostCreateServiceDto
                 (memberRepository.findByEmail("test").get().getId(), "testTitle2", "testContent2", false);
 
-            Post result1 = postCommandService.writePost(dto1);
-            Post result2 = postCommandService.writePost(dto2);
+            PostDetailResponseDto result1 = postCommandService.writePost(dto1);
+            PostDetailResponseDto result2 = postCommandService.writePost(dto2);
             Post postFromDB1 = postRepository.findById(result1.getId()).get();
             Post postFromDB2 = postRepository.findById(result2.getId()).get();
             postFromDB1.report();
@@ -83,8 +84,8 @@ public class AdminControllerTest {
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle2", "testContent2", false);
           
-            Post savedPost1 = postCommandService.writePost(dto1);
-            Post savedPost2 = postCommandService.writePost(dto2);
+            PostDetailResponseDto savedPost1 = postCommandService.writePost(dto1);
+            PostDetailResponseDto savedPost2 = postCommandService.writePost(dto2);
             Post postFromDB1 = postRepository.findById(savedPost1.getId()).get();
             Post postFromDB2 = postRepository.findById(savedPost2.getId()).get();
 
@@ -106,7 +107,7 @@ public class AdminControllerTest {
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
 
-            Post newPost = postCommandService.writePost(dto1);
+            PostDetailResponseDto newPost = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(newPost.getId()).get();
 
             post1.report();
@@ -126,7 +127,7 @@ public class AdminControllerTest {
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
 
-            Post newPost = postCommandService.writePost(dto1);
+            PostDetailResponseDto newPost = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(newPost.getId()).get();
 
             post1.report();
@@ -147,7 +148,7 @@ public class AdminControllerTest {
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
 
-            Post newPost = postCommandService.writePost(dto1);
+            PostDetailResponseDto newPost = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(newPost.getId()).get();
 
             //when, then
@@ -166,7 +167,7 @@ public class AdminControllerTest {
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
 
-            Post newPost = postCommandService.writePost(dto1);
+            PostDetailResponseDto newPost = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(newPost.getId()).get();
 
             post1.report();
@@ -186,7 +187,7 @@ public class AdminControllerTest {
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
 
-            Post newPost = postCommandService.writePost(dto1);
+            PostDetailResponseDto newPost = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(newPost.getId()).get();
 
             post1.report();

--- a/src/test/java/com/fasttime/domain/member/service/AdminServiceTest.java
+++ b/src/test/java/com/fasttime/domain/member/service/AdminServiceTest.java
@@ -3,6 +3,7 @@ package com.fasttime.domain.member.service;
 import com.fasttime.domain.member.dto.MemberDto;
 import com.fasttime.domain.member.repository.MemberRepository;
 import com.fasttime.domain.post.dto.service.request.PostCreateServiceDto;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.entity.ReportStatus;
 import com.fasttime.domain.post.repository.PostRepository;
@@ -53,8 +54,8 @@ public class AdminServiceTest {
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle2", "testContent2", false);
           
-            Post newPost1 = postCommandService.writePost(dto1);
-            Post newPost2 = postCommandService.writePost(dto2);
+            PostDetailResponseDto newPost1 = postCommandService.writePost(dto1);
+            PostDetailResponseDto newPost2 = postCommandService.writePost(dto2);
             Post post1 = postRepository.findById(newPost1.getId()).get();
             Post post2 = postRepository.findById(newPost2.getId()).get();
             post1.report();
@@ -79,8 +80,8 @@ public class AdminServiceTest {
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle2", "testContent2", false);
 
-            Post newPost1 = postCommandService.writePost(dto1);
-            Post newPost2 = postCommandService.writePost(dto2);
+            PostDetailResponseDto newPost1 = postCommandService.writePost(dto1);
+            PostDetailResponseDto newPost2 = postCommandService.writePost(dto2);
             Post post1 = postRepository.findById(newPost1.getId()).get();
             Post post2 = postRepository.findById(newPost2.getId()).get();
 
@@ -101,7 +102,7 @@ public class AdminServiceTest {
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
 
-            Post newPost = postCommandService.writePost(dto1);
+            PostDetailResponseDto newPost = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(newPost.getId()).get();
 
             post1.report();
@@ -119,7 +120,7 @@ public class AdminServiceTest {
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
 
-            Post newPost = postCommandService.writePost(dto1);
+            PostDetailResponseDto newPost = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(newPost.getId()).get();
 
             post1.report();
@@ -140,7 +141,7 @@ public class AdminServiceTest {
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
 
-            Post newPost = postCommandService.writePost(dto1);
+            PostDetailResponseDto newPost = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(newPost.getId()).get();
 
             //when ,then
@@ -155,7 +156,7 @@ public class AdminServiceTest {
                 (memberRepository.findByEmail("test").get().getId(),
                     "testTitle1", "testContent1", false);
 
-            Post newPost = postCommandService.writePost(dto1);
+            PostDetailResponseDto newPost = postCommandService.writePost(dto1);
             Post post1 = postRepository.findById(newPost.getId()).get();
 
             //when ,then

--- a/src/test/java/com/fasttime/domain/post/docs/PostControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/post/docs/PostControllerDocsTest.java
@@ -23,7 +23,6 @@ import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasttime.docs.RestDocsSupport;
-import com.fasttime.domain.member.entity.Member;
 import com.fasttime.domain.post.controller.PostController;
 import com.fasttime.domain.post.dto.controller.request.PostDeleteRequestDto;
 import com.fasttime.domain.post.dto.service.request.PostCreateServiceDto;
@@ -31,10 +30,10 @@ import com.fasttime.domain.post.dto.service.request.PostDeleteServiceDto;
 import com.fasttime.domain.post.dto.service.request.PostUpdateServiceDto;
 import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.dto.service.response.PostsResponseDto;
-import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.service.PostCommandUseCase;
 import com.fasttime.domain.post.service.PostQueryUseCase;
 import com.fasttime.domain.post.service.PostQueryUseCase.PostSearchCondition;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -61,12 +60,14 @@ class PostControllerDocsTest extends RestDocsSupport {
             "게시글 본문입니다.", false);
 
         when(postCommandUseCase.writePost(any(PostCreateServiceDto.class)))
-            .thenReturn(Post.builder()
+            .thenReturn(PostDetailResponseDto.builder()
                 .id(1L)
-                .member(Member.builder().id(1L).nickname("패캠러").build())
+                .nickname("패캠러")
                 .title(requestDto.getTitle())
                 .content(requestDto.getContent())
                 .anonymity(requestDto.isAnonymity())
+                .createdAt(LocalDateTime.now())
+                .lastModifiedAt(null)
                 .build());
 
         // when then
@@ -94,7 +95,9 @@ class PostControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("data.nickname").type(JsonFieldType.STRING).description("작성자 닉네임"),
                     fieldWithPath("data.anonymity").type(JsonFieldType.BOOLEAN).description("익명 여부"),
                     fieldWithPath("data.likeCount").type(JsonFieldType.NUMBER).description("좋아요 수"),
-                    fieldWithPath("data.hateCount").type(JsonFieldType.NUMBER).description("싫어요 수")
+                    fieldWithPath("data.hateCount").type(JsonFieldType.NUMBER).description("싫어요 수"),
+                    fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("생성 일시"),
+                    fieldWithPath("data.lastModifiedAt").type(JsonFieldType.NULL).description("최종 수정 일시")
                 )
             ));
     }
@@ -115,11 +118,11 @@ class PostControllerDocsTest extends RestDocsSupport {
         when(postQueryUseCase.searchPost(any(PostSearchCondition.class)))
             .thenReturn(List.of(
                 PostsResponseDto.builder().id(1L).title("공 잘 패스하는법 알려줌!").likeCount(20).hateCount(1)
-                    .nickname("패캠러").anonymity(false).build(),
+                    .nickname("패캠러").anonymity(false).createdAt(LocalDateTime.now()).lastModifiedAt(LocalDateTime.now()).build(),
                 PostsResponseDto.builder().id(2L).title("패스트캠퍼스를 아시나요?").likeCount(20).hateCount(5)
-                    .nickname("패캠러123").anonymity(false).build(),
+                    .nickname("패캠러123").anonymity(false).createdAt(LocalDateTime.now()).lastModifiedAt(LocalDateTime.now()).build(),
                 PostsResponseDto.builder().id(3L).title("공무원합격 패스는 ㅇㅇㅇ").likeCount(20).hateCount(3)
-                    .nickname("패컴러1").anonymity(false).build()
+                    .nickname("패컴러1").anonymity(false).createdAt(LocalDateTime.now()).lastModifiedAt(LocalDateTime.now()).build()
             ));
 
         // when then
@@ -154,7 +157,9 @@ class PostControllerDocsTest extends RestDocsSupport {
                         .description("익명 여부"),
                     fieldWithPath("data[].commentCounts").type(JsonFieldType.NUMBER).description("댓글 수"),
                     fieldWithPath("data[].likeCount").type(JsonFieldType.NUMBER).description("좋아요 수"),
-                    fieldWithPath("data[].hateCount").type(JsonFieldType.NUMBER).description("싫어요 수")
+                    fieldWithPath("data[].hateCount").type(JsonFieldType.NUMBER).description("싫어요 수"),
+                    fieldWithPath("data[].createdAt").type(JsonFieldType.STRING).description("생성 일시"),
+                    fieldWithPath("data[].lastModifiedAt").type(JsonFieldType.STRING).description("수정 일시")
                 )
             ));
     }
@@ -168,12 +173,14 @@ class PostControllerDocsTest extends RestDocsSupport {
             "게시글 본문입니다.", false);
 
         when(postQueryUseCase.findById(anyLong()))
-            .thenReturn(Post.builder()
+            .thenReturn(PostDetailResponseDto.builder()
                 .id(1L)
-                .member(Member.builder().id(1L).nickname("패캠러").build())
+                .nickname("패캠러")
                 .title(requestDto.getTitle())
                 .content(requestDto.getContent())
                 .anonymity(requestDto.isAnonymity())
+                .createdAt(LocalDateTime.now())
+                .lastModifiedAt(LocalDateTime.now())
                 .build());
 
         // when then
@@ -198,7 +205,9 @@ class PostControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("data.anonymity").type(JsonFieldType.BOOLEAN)
                         .description("익명 여부"),
                     fieldWithPath("data.likeCount").type(JsonFieldType.NUMBER).description("좋아요 수"),
-                    fieldWithPath("data.hateCount").type(JsonFieldType.NUMBER).description("싫어요 수")
+                    fieldWithPath("data.hateCount").type(JsonFieldType.NUMBER).description("싫어요 수"),
+                    fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("생성 일시"),
+                    fieldWithPath("data.lastModifiedAt").type(JsonFieldType.STRING).description("수정 일시")
                 )
             ));
     }
@@ -220,6 +229,8 @@ class PostControllerDocsTest extends RestDocsSupport {
                 .anonymity(false)
                 .likeCount(5)
                 .hateCount(1)
+                .createdAt(LocalDateTime.now())
+                .lastModifiedAt(LocalDateTime.now())
                 .build());
 
         // when then
@@ -249,7 +260,9 @@ class PostControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("data.anonymity").type(JsonFieldType.BOOLEAN)
                         .description("익명 여부"),
                     fieldWithPath("data.likeCount").type(JsonFieldType.NUMBER).description("좋아요 수"),
-                    fieldWithPath("data.hateCount").type(JsonFieldType.NUMBER).description("싫어요 수")
+                    fieldWithPath("data.hateCount").type(JsonFieldType.NUMBER).description("싫어요 수"),
+                    fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("생성 일시"),
+                    fieldWithPath("data.lastModifiedAt").type(JsonFieldType.STRING).description("수정 일시")
                 )
             ));
     }

--- a/src/test/java/com/fasttime/domain/post/unit/service/PostQueryServiceTest.java
+++ b/src/test/java/com/fasttime/domain/post/unit/service/PostQueryServiceTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
+import com.fasttime.domain.member.entity.Member;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.entity.ReportStatus;
 import com.fasttime.domain.post.exception.PostNotFoundException;
@@ -37,19 +39,20 @@ public class PostQueryServiceTest {
 
         @DisplayName("key를 넘기면 PostResponse를 반환한다.")
         @CsvSource(value = {
-            "1, 제목1, 내용1, true, 10, 20",
-            "2, 제목2, 내용2, false, 15, 30",
-            "3, 제목3, 내용3, true, 23, 35"
+            "1, 제목1, 내용1, 패캠러1, true, 10, 20",
+            "2, 제목2, 내용2, 패캠러2, false, 15, 30",
+            "3, 제목3, 내용3, 패캠러3, true, 23, 35"
         })
         @ParameterizedTest
         void inputKey_postResponse_willReturn(long id, String title, String content,
-            boolean anonymity, int likeCount, int hateCount) {
+            String nickname, boolean anonymity, int likeCount, int hateCount) {
 
             // given
             given(postRepository.findById(anyLong()))
                 .willReturn(Optional.of(Post.builder()
                     .id(id)
                     .title(title)
+                    .member(Member.builder().nickname(nickname).build())
                     .content(content)
                     .anonymity(anonymity)
                     .likeCount(likeCount)
@@ -58,14 +61,12 @@ public class PostQueryServiceTest {
                     .build()));
 
             // when
-            Post postEntity = postQueryService.findById(id);
+            PostDetailResponseDto response = postQueryService.findById(id);
 
             // then
-            assertThat(postEntity)
-                .extracting("id", "title", "content", "anonymity", "likeCount", "hateCount",
-                    "reportStatus")
-                .containsExactly(id, title, content, anonymity, likeCount, hateCount,
-                    ReportStatus.NORMAL);
+            assertThat(response)
+                .extracting("id", "title", "content", "nickname", "anonymity", "likeCount", "hateCount")
+                .containsExactly(id, title, content, nickname, anonymity, likeCount, hateCount);
         }
 
         @DisplayName("DB에 해당 id 를 가지는 게시글이 없다면 IllegalArgumentException을 던진다.")


### PR DESCRIPTION
Motivation:

- Post Entity를 반환하는 API를 제공했지만, 요구사항이 자주 변경하면서 이를 사용하는 모듈들에 영향이 가는 문제를 겪게되었습니다.

- 위의 문제로 인해 해당 API를 독립적인 DTO로 변경하게 되었습니다.

Modification:

- PostQueryUseCase.findById() 의 return type 을 Post 에서 PostDetailResponseDto 로 변경.
- 해당 API를 사용하는 Admin, Comment 모듈 변경.