### PR TITLE
[feat] 댓글 API Spring REST Docs 도입

### DIFF
--- a/src/docs/asciidoc/comment/comment-api.adoc
+++ b/src/docs/asciidoc/comment/comment-api.adoc
@@ -1,0 +1,78 @@
+= Comment REST API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+[[Comment-Create]]
+== 댓글 등록
+
+회원이 게시글에 댓글을 등록하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/comment-create/http-request.adoc[]
+include::{snippets}/comment-create/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/comment-create/http-response.adoc[]
+include::{snippets}/comment-create/response-fields.adoc[]
+
+[[Comment-Search-Post]]
+== 게시글 페이지 댓글 목록 조회
+
+게시글 상세 페이지에서 댓글을 조회하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/comments-search-post/http-request.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/comments-search-post/http-response.adoc[]
+include::{snippets}/comments-search-post/response-fields.adoc[]
+
+[[Comment-Search-MyPage]]
+== 마이 페이지 댓글 목록 조회
+
+마이 페이지에서 회원이 남긴 댓글을 조회하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/comments-search-mypage/http-request.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/comments-search-mypage/http-response.adoc[]
+include::{snippets}/comments-search-mypage/response-fields.adoc[]
+
+[[Comment-Update]]
+== 댓글 수정
+
+회원이 댓글 내용을 수정하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/comment-update/http-request.adoc[]
+include::{snippets}/comment-update/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/comment-update/http-response.adoc[]
+include::{snippets}/comment-update/response-fields.adoc[]
+
+[[Comment-Delete]]
+== 댓글 삭제
+
+회원이 댓글을 삭제하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/comment-delete/http-request.adoc[]
+include::{snippets}/comment-delete/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/comment-delete/http-response.adoc[]

--- a/src/test/java/com/fasttime/domain/comment/docs/CommentControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/comment/docs/CommentControllerDocsTest.java
@@ -14,6 +14,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,6 +30,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.constraints.ConstraintDescriptions;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -40,6 +42,13 @@ public class CommentControllerDocsTest extends RestDocsSupport {
     public Object initController() {
         return new CommentRestController(commentService);
     }
+
+    ConstraintDescriptions CreateCommentRequestConstraints = new ConstraintDescriptions(
+        CreateCommentRequest.class);
+    ConstraintDescriptions UpdateCommentRequestConstraints = new ConstraintDescriptions(
+        UpdateCommentRequest.class);
+    ConstraintDescriptions DeleteCommentRequestConstraints = new ConstraintDescriptions(
+        DeleteCommentRequest.class);
 
     @DisplayName("댓글 등록 API 문서화")
     @Test
@@ -60,10 +69,18 @@ public class CommentControllerDocsTest extends RestDocsSupport {
             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isCreated()).andDo(
             document("comment-create", preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()), requestFields(
-                    fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자"),
-                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자"),
-                    fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
-                    fieldWithPath("anonymity").type(JsonFieldType.BOOLEAN).description("익명여부"),
+                    fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자")
+                        .attributes(key("constraints").value(
+                            CreateCommentRequestConstraints.descriptionsForProperty("postId"))),
+                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자")
+                        .attributes(key("constraints").value(
+                            CreateCommentRequestConstraints.descriptionsForProperty("memberId"))),
+                    fieldWithPath("content").type(JsonFieldType.STRING).description("내용")
+                        .attributes(key("constraints").value(
+                            CreateCommentRequestConstraints.descriptionsForProperty("content"))),
+                    fieldWithPath("anonymity").type(JsonFieldType.BOOLEAN).description("익명여부")
+                        .attributes(key("constraints").value(
+                            CreateCommentRequestConstraints.descriptionsForProperty("anonymity"))),
                     fieldWithPath("parentCommentId").type(JsonFieldType.NUMBER).optional()
                         .description("부모 댓글 식별자")), responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
@@ -184,9 +201,13 @@ public class CommentControllerDocsTest extends RestDocsSupport {
                 patch("/api/v1/comment").contentType(MediaType.APPLICATION_JSON).content(json))
             .andExpect(status().isOk()).andDo(
                 document("comment-update", preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    requestFields(fieldWithPath("id").type(JsonFieldType.NUMBER).description("댓글 식별자"),
-                        fieldWithPath("content").type(JsonFieldType.STRING).description("내용")),
+                    preprocessResponse(prettyPrint()), requestFields(
+                        fieldWithPath("id").type(JsonFieldType.NUMBER).description("댓글 식별자").attributes(
+                            key("constraints").value(
+                                UpdateCommentRequestConstraints.descriptionsForProperty("id"))),
+                        fieldWithPath("content").type(JsonFieldType.STRING).description("내용")
+                            .attributes(key("constraints").value(
+                                UpdateCommentRequestConstraints.descriptionsForProperty("content")))),
                     responseFields(
                         fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
@@ -218,8 +239,10 @@ public class CommentControllerDocsTest extends RestDocsSupport {
         mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/comment").content(json)
             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk()).andDo(
             document("comment-delete", preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                requestFields(fieldWithPath("id").type(JsonFieldType.NUMBER).description("댓글 식별자")),
+                preprocessResponse(prettyPrint()), requestFields(
+                    fieldWithPath("id").type(JsonFieldType.NUMBER).description("댓글 식별자").attributes(
+                        key("constraints").value(
+                            DeleteCommentRequestConstraints.descriptionsForProperty("id")))),
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),

--- a/src/test/java/com/fasttime/domain/comment/docs/CommentControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/comment/docs/CommentControllerDocsTest.java
@@ -1,0 +1,228 @@
+package com.fasttime.domain.comment.docs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasttime.docs.RestDocsSupport;
+import com.fasttime.domain.comment.controller.CommentRestController;
+import com.fasttime.domain.comment.dto.request.CreateCommentRequest;
+import com.fasttime.domain.comment.dto.request.DeleteCommentRequest;
+import com.fasttime.domain.comment.dto.request.UpdateCommentRequest;
+import com.fasttime.domain.comment.dto.response.MyPageCommentResponseDTO;
+import com.fasttime.domain.comment.dto.response.PostCommentResponseDTO;
+import com.fasttime.domain.comment.service.CommentService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+public class CommentControllerDocsTest extends RestDocsSupport {
+
+    private final CommentService commentService = mock(CommentService.class);
+
+    @Override
+    public Object initController() {
+        return new CommentRestController(commentService);
+    }
+
+    @DisplayName("댓글 등록 API 문서화")
+    @Test
+    void createComment() throws Exception {
+        // given
+        CreateCommentRequest request = CreateCommentRequest.builder().postId(1L).memberId(1L)
+            .content("test").anonymity(false).parentCommentId(null).build();
+        PostCommentResponseDTO postCommentResponseDto = PostCommentResponseDTO.builder().id(1L)
+            .memberId(1L).nickname("nickname").content("test").anonymity(false)
+            .parentCommentId(null).createdAt("2023-01-01 12:30:00").updatedAt(null).deletedAt(null)
+            .build();
+        given(commentService.createComment(any(CreateCommentRequest.class))).willReturn(
+            postCommentResponseDto);
+        String json = new ObjectMapper().writeValueAsString(request);
+
+        // when, then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/comment").content(json)
+            .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isCreated()).andDo(
+            document("comment-create", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()), requestFields(
+                    fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자"),
+                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자"),
+                    fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
+                    fieldWithPath("anonymity").type(JsonFieldType.BOOLEAN).description("익명여부"),
+                    fieldWithPath("parentCommentId").type(JsonFieldType.NUMBER).optional()
+                        .description("부모 댓글 식별자")), responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+                    fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답데이터"),
+                    fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("댓글 식별자"),
+                    fieldWithPath("data.memberId").type(JsonFieldType.NUMBER).description("회원 식별자"),
+                    fieldWithPath("data.nickname").type(JsonFieldType.STRING)
+                        .description("작성자 닉네임"),
+                    fieldWithPath("data.content").type(JsonFieldType.STRING).description("댓글 내용"),
+                    fieldWithPath("data.anonymity").type(JsonFieldType.BOOLEAN)
+                        .description("익명 여부"),
+                    fieldWithPath("data.parentCommentId").type(JsonFieldType.NUMBER).optional()
+                        .description("부모 댓글 식별자"),
+                    fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("등록 일시"),
+                    fieldWithPath("data.updatedAt").type(JsonFieldType.STRING).optional()
+                        .description("수정 일시"),
+                    fieldWithPath("data.deletedAt").type(JsonFieldType.STRING).optional()
+                        .description("삭제 일시"))));
+    }
+
+    @DisplayName("마이 페이지 댓글 목록 조회 API 문서화")
+    @Test
+    void getCommentsByMemberId() throws Exception {
+        // given
+        when(commentService.getCommentsByMemberId(any(Long.class))).thenReturn(List.of(
+            MyPageCommentResponseDTO.builder().id(1L).postId(1L).nickname("nickname1")
+                .content("좋은 글 잘 보고 갑니다.").anonymity(true).parentCommentId(null)
+                .createdAt("2023-01-01 12:30:00").updatedAt(null).deletedAt(null).build(),
+            MyPageCommentResponseDTO.builder().id(2L).postId(2L).nickname("nickname1")
+                .content("이유가 뭔가요?").anonymity(true).parentCommentId(1L)
+                .createdAt("2023-01-01 12:35:00").updatedAt(null).deletedAt(null).build(),
+            MyPageCommentResponseDTO.builder().id(3L).postId(2L).nickname("nickname1")
+                .content("아하!").anonymity(true).parentCommentId(1L).createdAt("2023-01-01 12:37:00")
+                .updatedAt(null).deletedAt(null).build()));
+
+        // when, then
+        mockMvc.perform(get("/api/v1/comment/my-page/{memberId}", 1)).andExpect(status().isOk())
+            .andDo(document("comments-search-mypage", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()), responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+                    fieldWithPath("data").type(JsonFieldType.ARRAY).description("응답데이터"),
+                    fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("댓글 식별자"),
+                    fieldWithPath("data[].postId").type(JsonFieldType.NUMBER)
+                        .description("게시글 식별자"),
+                    fieldWithPath("data[].nickname").type(JsonFieldType.STRING)
+                        .description("작성자 닉네임"),
+                    fieldWithPath("data[].content").type(JsonFieldType.STRING).description("댓글 내용"),
+                    fieldWithPath("data[].anonymity").type(JsonFieldType.BOOLEAN)
+                        .description("익명 여부"),
+                    fieldWithPath("data[].parentCommentId").type(JsonFieldType.NUMBER).optional()
+                        .description("부모 댓글 식별자"),
+                    fieldWithPath("data[].createdAt").type(JsonFieldType.STRING)
+                        .description("등록 일시"),
+                    fieldWithPath("data[].updatedAt").type(JsonFieldType.STRING).optional()
+                        .description("수정 일시"),
+                    fieldWithPath("data[].deletedAt").type(JsonFieldType.STRING).optional()
+                        .description("삭제 일시"))));
+    }
+
+    @DisplayName("게시글 상세 페이지 댓글 목록 조회 API 문서화")
+    @Test
+    void getCommentsByPostId() throws Exception {
+        // given
+        when(commentService.getCommentsByPostId(any(Long.class))).thenReturn(List.of(
+            PostCommentResponseDTO.builder().id(1L).memberId(1L).nickname("nickname1")
+                .content("공감합니다.").anonymity(false).parentCommentId(null)
+                .createdAt("2023-01-01 12:30:00").updatedAt(null).deletedAt(null).build(),
+            PostCommentResponseDTO.builder().id(2L).memberId(2L).nickname("nickname2")
+                .content("저도요.").anonymity(true).parentCommentId(1L)
+                .createdAt("2023-01-01 12:40:00").updatedAt(null).deletedAt(null).build(),
+            PostCommentResponseDTO.builder().id(3L).memberId(1L).nickname("nickname1")
+                .content("역시 다들 비슷하네요.").anonymity(false).parentCommentId(1L)
+                .createdAt("2023-01-01 12:42:00").updatedAt(null).deletedAt(null).build()));
+
+        // when, then
+        mockMvc.perform(get("/api/v1/comment/{postId}", 1)).andExpect(status().isOk()).andDo(
+            document("comments-search-post", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()), responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+                    fieldWithPath("data").type(JsonFieldType.ARRAY).description("응답데이터"),
+                    fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("댓글 식별자"),
+                    fieldWithPath("data[].memberId").type(JsonFieldType.NUMBER)
+                        .description("회원 식별자"),
+                    fieldWithPath("data[].nickname").type(JsonFieldType.STRING)
+                        .description("작성자 닉네임"),
+                    fieldWithPath("data[].content").type(JsonFieldType.STRING).description("댓글 내용"),
+                    fieldWithPath("data[].anonymity").type(JsonFieldType.BOOLEAN)
+                        .description("익명 여부"),
+                    fieldWithPath("data[].parentCommentId").type(JsonFieldType.NUMBER).optional()
+                        .description("부모 댓글 식별자"),
+                    fieldWithPath("data[].createdAt").type(JsonFieldType.STRING)
+                        .description("등록 일시"),
+                    fieldWithPath("data[].updatedAt").type(JsonFieldType.STRING).optional()
+                        .description("수정 일시"),
+                    fieldWithPath("data[].deletedAt").type(JsonFieldType.STRING).optional()
+                        .description("삭제 일시"))));
+    }
+
+    @DisplayName("게시글 수정 API 문서화")
+    @Test
+    void postUpdate() throws Exception {
+        // given
+        UpdateCommentRequest request = UpdateCommentRequest.builder().id(1L).content("modified")
+            .build();
+        PostCommentResponseDTO postCommentResponseDto = PostCommentResponseDTO.builder().id(2L)
+            .memberId(2L).nickname("nickname2").content("감사합니다. -수정").anonymity(true)
+            .parentCommentId(1L).createdAt("2023-01-01 12:40:00").updatedAt("2023-01-01 12:41:00")
+            .deletedAt(null).build();
+        given(commentService.updateComment(any(UpdateCommentRequest.class))).willReturn(
+            postCommentResponseDto);
+        String json = new ObjectMapper().writeValueAsString(request);
+
+        // when, then
+        mockMvc.perform(
+                patch("/api/v1/comment").contentType(MediaType.APPLICATION_JSON).content(json))
+            .andExpect(status().isOk()).andDo(
+                document("comment-update", preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestFields(fieldWithPath("id").type(JsonFieldType.NUMBER).description("댓글 식별자"),
+                        fieldWithPath("content").type(JsonFieldType.STRING).description("내용")),
+                    responseFields(
+                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답데이터"),
+                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("댓글 식별자"),
+                        fieldWithPath("data.memberId").type(JsonFieldType.NUMBER).description("회원 식별자"),
+                        fieldWithPath("data.nickname").type(JsonFieldType.STRING)
+                            .description("작성자 닉네임"),
+                        fieldWithPath("data.content").type(JsonFieldType.STRING).description("댓글 내용"),
+                        fieldWithPath("data.anonymity").type(JsonFieldType.BOOLEAN)
+                            .description("익명 여부"),
+                        fieldWithPath("data.parentCommentId").type(JsonFieldType.NUMBER).optional()
+                            .description("부모 댓글 식별자"),
+                        fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("등록 일시"),
+                        fieldWithPath("data.updatedAt").type(JsonFieldType.STRING).description("수정 일시"),
+                        fieldWithPath("data.deletedAt").type(JsonFieldType.STRING).optional()
+                            .description("삭제 일시"))));
+    }
+
+    @DisplayName("게시글 삭제 API 문서화")
+    @Test
+    void postDelete() throws Exception {
+        // given
+        DeleteCommentRequest request = DeleteCommentRequest.builder().id(0L).build();
+        String json = new ObjectMapper().writeValueAsString(request);
+        doNothing().when(commentService).deleteComment(any(DeleteCommentRequest.class));
+
+        // when, then
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/comment").content(json)
+            .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk()).andDo(
+            document("comment-delete", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(fieldWithPath("id").type(JsonFieldType.NUMBER).description("댓글 식별자")),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+                    fieldWithPath("data").type(JsonFieldType.NULL).description("응답데이터"))));
+    }
+}

--- a/src/test/java/com/fasttime/domain/comment/unit/controller/CommentRestControllerTest.java
+++ b/src/test/java/com/fasttime/domain/comment/unit/controller/CommentRestControllerTest.java
@@ -1,4 +1,4 @@
-package com.fasttime.domain.comment.controller;
+package com.fasttime.domain.comment.unit.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasttime.domain.comment.controller.CommentRestController;
 import com.fasttime.domain.comment.dto.request.CreateCommentRequest;
 import com.fasttime.domain.comment.dto.request.DeleteCommentRequest;
 import com.fasttime.domain.comment.dto.request.UpdateCommentRequest;

--- a/src/test/java/com/fasttime/domain/comment/unit/entity/CommentTest.java
+++ b/src/test/java/com/fasttime/domain/comment/unit/entity/CommentTest.java
@@ -1,7 +1,8 @@
-package com.fasttime.domain.comment.entity;
+package com.fasttime.domain.comment.unit.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasttime.domain.comment.entity.Comment;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/fasttime/domain/comment/unit/service/CommentServiceTest.java
+++ b/src/test/java/com/fasttime/domain/comment/unit/service/CommentServiceTest.java
@@ -1,4 +1,4 @@
-package com.fasttime.domain.comment.service;
+package com.fasttime.domain.comment.unit.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,6 +17,7 @@ import com.fasttime.domain.comment.dto.response.PostCommentResponseDTO;
 import com.fasttime.domain.comment.entity.Comment;
 import com.fasttime.domain.comment.exception.CommentNotFoundException;
 import com.fasttime.domain.comment.repository.CommentRepository;
+import com.fasttime.domain.comment.service.CommentService;
 import com.fasttime.domain.member.entity.Member;
 import com.fasttime.domain.member.exception.UserNotFoundException;
 import com.fasttime.domain.member.service.MemberService;


### PR DESCRIPTION
## 개발 내용
Spring REST Docs를 사용하여 API 문서를 작성했습니다. 

- 댓글 REST API Docs를 위한 테스트 추가
- 댓글 API .adoc 구현