### PR TITLE
[fix] WebConfig Profile 삭제

### DIFF
--- a/src/main/java/com/fasttime/global/config/WebConfig.java
+++ b/src/main/java/com/fasttime/global/config/WebConfig.java
@@ -3,16 +3,14 @@ package com.fasttime.global.config;
 import com.fasttime.global.interceptor.AdminCheckInterceptor;
 import com.fasttime.global.interceptor.LoginCheckInterceptor;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-@Profile({"local, prod"})
 public class WebConfig implements WebMvcConfigurer {
 
-    @Override
+        @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new AdminCheckInterceptor())
             .order(1)
@@ -24,7 +22,9 @@ public class WebConfig implements WebMvcConfigurer {
     }
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**").allowedOriginPatterns("*").allowedMethods("GET", "POST", "PUT", "DELETE","OPTIONS");
+        registry.addMapping("/**")
+            .allowedOriginPatterns("*")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
     }
 
 }

--- a/src/main/java/com/fasttime/global/config/WebConfig.java
+++ b/src/main/java/com/fasttime/global/config/WebConfig.java
@@ -3,14 +3,16 @@ package com.fasttime.global.config;
 import com.fasttime.global.interceptor.AdminCheckInterceptor;
 import com.fasttime.global.interceptor.LoginCheckInterceptor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@Profile("!test")
 public class WebConfig implements WebMvcConfigurer {
 
-        @Override
+    @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new AdminCheckInterceptor())
             .order(1)
@@ -20,6 +22,7 @@ public class WebConfig implements WebMvcConfigurer {
             .addPathPatterns("/api/v1/comment/**",
                 "/api/v1/retouch-member", "/api/v1/logout", "/api/v1/delete");
     }
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")

--- a/src/main/java/com/fasttime/global/config/WebConfig.java
+++ b/src/main/java/com/fasttime/global/config/WebConfig.java
@@ -27,7 +27,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
             .allowedOriginPatterns("*")
-            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS");
     }
 
 }


### PR DESCRIPTION
Motivation:
- 잘못된 @Profile 설정으로 인해 몇몇 실행 Profile 에서 WebConfig 설정이 작동하지 않는 것을 발견했습니다.

- 위 문제를 해결하기 위해 우선적으로 @Profile 을 제거하기로 결정했습니다.

Modification:
- `WebConfig.class`의 `@Profile` 제거