### PR TITLE
[fix] EnableJpaAuditing Enable

### DIFF
--- a/src/main/java/com/fasttime/global/config/JpaAuditConfiguration.java
+++ b/src/main/java/com/fasttime/global/config/JpaAuditConfiguration.java
@@ -1,8 +1,10 @@
 package com.fasttime.global.config;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@Configuration
 class JpaAuditConfiguration {
 
 }


### PR DESCRIPTION
Motivation:
- @EnableJpaAuditing 이 작성되었지만 Bean으로 등록되어있지 않았기 떄문에 실행이 안되고 있었습니다.
- 위의 문제를 수정했습니다.

Modification:

- `JpaAuditConfiguration.class` 에 `@Configuration` 등록