### PR TITLE
[feat] 신고 Spring API Docs 도입

### DIFF
--- a/src/docs/asciidoc/report/report-api.adoc
+++ b/src/docs/asciidoc/report/report-api.adoc
@@ -1,0 +1,21 @@
+= Report REST API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+[[Report-Create]]
+== 신고 등록
+
+회원이 게시글을 신고하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/report-create/http-request.adoc[]
+include::{snippets}/report-create/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/report-create/http-response.adoc[]
+include::{snippets}/report-create/response-fields.adoc[]

--- a/src/main/java/com/fasttime/domain/report/contoller/ReportRestController.java
+++ b/src/main/java/com/fasttime/domain/report/contoller/ReportRestController.java
@@ -1,5 +1,6 @@
 package com.fasttime.domain.report.contoller;
 
+import com.fasttime.domain.report.dto.ReportDTO;
 import com.fasttime.domain.report.dto.request.CreateReportRequest;
 import com.fasttime.domain.report.service.ReportService;
 import com.fasttime.global.util.ResponseDTO;
@@ -22,7 +23,7 @@ public class ReportRestController {
     private final ReportService reportService;
 
     @PostMapping("/create")
-    public ResponseEntity<ResponseDTO<Object>> create(
+    public ResponseEntity<ResponseDTO<ReportDTO>> create(
         @Valid @RequestBody CreateReportRequest createReportRequest) {
         log.info("CreateReportRequest: " + createReportRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(

--- a/src/test/java/com/fasttime/domain/comment/docs/CommentControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/comment/docs/CommentControllerDocsTest.java
@@ -45,11 +45,11 @@ public class CommentControllerDocsTest extends RestDocsSupport {
         return new CommentRestController(commentService);
     }
 
-    ConstraintDescriptions CreateCommentRequestConstraints = new ConstraintDescriptions(
+    ConstraintDescriptions createCommentRequestConstraints = new ConstraintDescriptions(
         CreateCommentRequest.class);
-    ConstraintDescriptions UpdateCommentRequestConstraints = new ConstraintDescriptions(
+    ConstraintDescriptions updateCommentRequestConstraints = new ConstraintDescriptions(
         UpdateCommentRequest.class);
-    ConstraintDescriptions DeleteCommentRequestConstraints = new ConstraintDescriptions(
+    ConstraintDescriptions deleteCommentRequestConstraints = new ConstraintDescriptions(
         DeleteCommentRequest.class);
 
     @DisplayName("댓글 등록 API 문서화")
@@ -73,16 +73,16 @@ public class CommentControllerDocsTest extends RestDocsSupport {
                 preprocessResponse(prettyPrint()), requestFields(
                     fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자")
                         .attributes(key("constraints").value(
-                            CreateCommentRequestConstraints.descriptionsForProperty("postId"))),
+                            createCommentRequestConstraints.descriptionsForProperty("postId"))),
                     fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자")
                         .attributes(key("constraints").value(
-                            CreateCommentRequestConstraints.descriptionsForProperty("memberId"))),
+                            createCommentRequestConstraints.descriptionsForProperty("memberId"))),
                     fieldWithPath("content").type(JsonFieldType.STRING).description("내용")
                         .attributes(key("constraints").value(
-                            CreateCommentRequestConstraints.descriptionsForProperty("content"))),
+                            createCommentRequestConstraints.descriptionsForProperty("content"))),
                     fieldWithPath("anonymity").type(JsonFieldType.BOOLEAN).description("익명여부")
                         .attributes(key("constraints").value(
-                            CreateCommentRequestConstraints.descriptionsForProperty("anonymity"))),
+                            createCommentRequestConstraints.descriptionsForProperty("anonymity"))),
                     fieldWithPath("parentCommentId").type(JsonFieldType.NUMBER).optional()
                         .description("부모 댓글 식별자")), responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
@@ -208,10 +208,10 @@ public class CommentControllerDocsTest extends RestDocsSupport {
                     preprocessResponse(prettyPrint()), requestFields(
                         fieldWithPath("id").type(JsonFieldType.NUMBER).description("댓글 식별자").attributes(
                             key("constraints").value(
-                                UpdateCommentRequestConstraints.descriptionsForProperty("id"))),
+                                updateCommentRequestConstraints.descriptionsForProperty("id"))),
                         fieldWithPath("content").type(JsonFieldType.STRING).description("내용")
                             .attributes(key("constraints").value(
-                                UpdateCommentRequestConstraints.descriptionsForProperty("content")))),
+                                updateCommentRequestConstraints.descriptionsForProperty("content")))),
                     responseFields(
                         fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
@@ -246,7 +246,7 @@ public class CommentControllerDocsTest extends RestDocsSupport {
                 preprocessResponse(prettyPrint()), requestFields(
                     fieldWithPath("id").type(JsonFieldType.NUMBER).description("댓글 식별자").attributes(
                         key("constraints").value(
-                            DeleteCommentRequestConstraints.descriptionsForProperty("id")))),
+                            deleteCommentRequestConstraints.descriptionsForProperty("id")))),
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),

--- a/src/test/java/com/fasttime/domain/report/docs/ReportControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/report/docs/ReportControllerDocsTest.java
@@ -1,0 +1,71 @@
+package com.fasttime.domain.report.docs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasttime.docs.RestDocsSupport;
+import com.fasttime.domain.report.contoller.ReportRestController;
+import com.fasttime.domain.report.dto.ReportDTO;
+import com.fasttime.domain.report.dto.request.CreateReportRequest;
+import com.fasttime.domain.report.service.ReportService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.constraints.ConstraintDescriptions;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+public class ReportControllerDocsTest extends RestDocsSupport {
+
+    private final ReportService reportService = mock(ReportService.class);
+
+    @Override
+    public Object initController() {
+        return new ReportRestController(reportService);
+    }
+
+    ConstraintDescriptions createReportRequestConstraints = new ConstraintDescriptions(
+        CreateReportRequest.class);
+
+    @DisplayName("신고 등록 API 문서화")
+    @Test
+    void createReport() throws Exception {
+        // given
+        CreateReportRequest request = CreateReportRequest.builder().postId(0L).memberId(0L).build();
+        ReportDTO reportDTO = ReportDTO.builder().id(0L).postId(0L).memberId(0L).build();
+        given(reportService.createReport(any(CreateReportRequest.class))).willReturn(reportDTO);
+        String json = new ObjectMapper().writeValueAsString(request);
+
+        // when, then
+        mockMvc.perform(
+                post("/api/v1/report/create").content(json).contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated()).andDo(
+                document("report-create", preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()), requestFields(
+                        fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자")
+                            .attributes(key("constraints").value(
+                                createReportRequestConstraints.descriptionsForProperty("postId"))),
+                        fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자")
+                            .attributes(key("constraints").value(
+                                createReportRequestConstraints.descriptionsForProperty("memberId")))),
+                    responseFields(
+                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답데이터"),
+                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("신고 식별자"),
+                        fieldWithPath("data.postId").type(JsonFieldType.NUMBER).description("게시글 식별자"),
+                        fieldWithPath("data.memberId").type(JsonFieldType.NUMBER)
+                            .description("회원 식별자"))));
+    }
+}

--- a/src/test/java/com/fasttime/domain/report/unit/controller/ReportRestControllerTest.java
+++ b/src/test/java/com/fasttime/domain/report/unit/controller/ReportRestControllerTest.java
@@ -1,4 +1,4 @@
-package com.fasttime.domain.report.controller;
+package com.fasttime.domain.report.unit.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/com/fasttime/domain/report/unit/entity/ReportTest.java
+++ b/src/test/java/com/fasttime/domain/report/unit/entity/ReportTest.java
@@ -1,9 +1,10 @@
-package com.fasttime.domain.report.entity;
+package com.fasttime.domain.report.unit.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasttime.domain.member.entity.Member;
 import com.fasttime.domain.post.entity.Post;
+import com.fasttime.domain.report.entity.Report;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/fasttime/domain/report/unit/service/ReportServiceTest.java
+++ b/src/test/java/com/fasttime/domain/report/unit/service/ReportServiceTest.java
@@ -1,4 +1,4 @@
-package com.fasttime.domain.report.service;
+package com.fasttime.domain.report.unit.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,6 +22,7 @@ import com.fasttime.domain.report.entity.Report;
 import com.fasttime.domain.report.exception.AlreadyDeletedPostException;
 import com.fasttime.domain.report.exception.DuplicateReportException;
 import com.fasttime.domain.report.repository.ReportRepository;
+import com.fasttime.domain.report.service.ReportService;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
## 개발 내용
Spring REST Docs를 사용하여 신고 API 문서를 만들었습니다. 

- Spring REST Docs를 위해 ReportControllerDocsTest 작성
- 신고 API .adoc 작성