### PR TITLE
[feat] 게시글 좋아요/싫어요 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -15,6 +15,8 @@ endif::[]
 === link:post/post-api.html[게시글 API, window=blank]
 === link:comment/comment-api.html[댓글 API, window=blank]
 === link:admin/admin-api.html[어드민 API, window=blank]
+=== link:report/report-api.html[신고 API, window=blank]
+=== link:record/record-api.html[좋아요/싫어요 API, window=blank]
 
 == API Common Response
 [[overview-http-status-code]]

--- a/src/docs/asciidoc/record/record-api.adoc
+++ b/src/docs/asciidoc/record/record-api.adoc
@@ -35,6 +35,21 @@ include::{snippets}/record-hate-create/request-fields.adoc[]
 include::{snippets}/record-hate-create/http-response.adoc[]
 include::{snippets}/record-hate-create/response-fields.adoc[]
 
+[[Record-Get]]
+== 좋아요/싫어요 조회
+
+게시글 좋아요/싫어요 내역을 조회 하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/record-get/http-request.adoc[]
+include::{snippets}/record-get/path-parameters.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/record-get/http-response.adoc[]
+include::{snippets}/record-get/response-fields.adoc[]
+
 [[Record-Delete]]
 == 좋아요/싫어요 취소
 

--- a/src/docs/asciidoc/record/record-api.adoc
+++ b/src/docs/asciidoc/record/record-api.adoc
@@ -1,0 +1,51 @@
+= Record REST API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+[[Record-Like-Create]]
+== 좋아요 등록
+
+회원이 게시글을 좋아요 하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/record-like-create/http-request.adoc[]
+include::{snippets}/record-like-create/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/record-like-create/http-response.adoc[]
+include::{snippets}/record-like-create/response-fields.adoc[]
+
+[[Record-Hate-Create]]
+== 싫어요 등록
+
+회원이 게시글을 싫어요 하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/record-hate-create/http-request.adoc[]
+include::{snippets}/record-hate-create/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/record-hate-create/http-response.adoc[]
+include::{snippets}/record-hate-create/response-fields.adoc[]
+
+[[Record-Delete]]
+== 좋아요/싫어요 취소
+
+회원이 게시글 좋아요/싫어요를 취소하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/record-delete/http-request.adoc[]
+include::{snippets}/record-delete/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/record-delete/http-response.adoc[]
+include::{snippets}/record-delete/response-fields.adoc[]

--- a/src/main/java/com/fasttime/domain/record/controller/RecordRestController.java
+++ b/src/main/java/com/fasttime/domain/record/controller/RecordRestController.java
@@ -37,7 +37,7 @@ public class RecordRestController {
     }
 
     @PostMapping("/hate")
-    public ResponseEntity<ResponseDTO<Void>> createHate(
+    public ResponseEntity<ResponseDTO<RecordDTO>> createHate(
         @Valid @RequestBody CreateRecordRequestDTO createRecordRequestDTO) {
         log.info("CreateRecordRequest: " + createRecordRequestDTO + "(hate)");
         recordService.createRecord(createRecordRequestDTO, false);

--- a/src/main/java/com/fasttime/domain/record/controller/RecordRestController.java
+++ b/src/main/java/com/fasttime/domain/record/controller/RecordRestController.java
@@ -1,0 +1,52 @@
+package com.fasttime.domain.record.controller;
+
+import com.fasttime.domain.record.dto.request.CreateRecordRequestDTO;
+import com.fasttime.domain.record.dto.request.DeleteRecordRequestDTO;
+import com.fasttime.domain.record.service.RecordService;
+import com.fasttime.global.util.ResponseDTO;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/record")
+public class RecordRestController {
+
+    private final RecordService recordService;
+
+    @PostMapping("/like")
+    public ResponseEntity<ResponseDTO<Void>> createLike(
+        @Valid @RequestBody CreateRecordRequestDTO createRecordRequestDTO) {
+        log.info("CreateRecordRequest: " + createRecordRequestDTO + "(like)");
+        recordService.createRecord(createRecordRequestDTO, true);
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ResponseDTO.res(HttpStatus.CREATED, "좋아요를 성공적으로 접수했습니다.", null));
+    }
+
+    @PostMapping("/hate")
+    public ResponseEntity<ResponseDTO<Void>> createHate(
+        @Valid @RequestBody CreateRecordRequestDTO createRecordRequestDTO) {
+        log.info("CreateRecordRequest: " + createRecordRequestDTO + "(hate)");
+        recordService.createRecord(createRecordRequestDTO, false);
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ResponseDTO.res(HttpStatus.CREATED, "싫어요를 성공적으로 접수했습니다.", null));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<ResponseDTO<Void>> deleteRecord(
+        @Valid @RequestBody DeleteRecordRequestDTO deleteRecordRequestDTO) {
+        log.info("DeleteRecordRequest: " + deleteRecordRequestDTO);
+        recordService.deleteRecord(deleteRecordRequestDTO);
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ResponseDTO.res(HttpStatus.OK, "좋아요/싫어요를 성공적으로 취소했습니다.", null));
+    }
+}

--- a/src/main/java/com/fasttime/domain/record/controller/RecordRestController.java
+++ b/src/main/java/com/fasttime/domain/record/controller/RecordRestController.java
@@ -1,15 +1,19 @@
 package com.fasttime.domain.record.controller;
 
+import com.fasttime.domain.record.dto.RecordDTO;
 import com.fasttime.domain.record.dto.request.CreateRecordRequestDTO;
 import com.fasttime.domain.record.dto.request.DeleteRecordRequestDTO;
 import com.fasttime.domain.record.service.RecordService;
 import com.fasttime.global.util.ResponseDTO;
+import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -39,6 +43,16 @@ public class RecordRestController {
         recordService.createRecord(createRecordRequestDTO, false);
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(ResponseDTO.res(HttpStatus.CREATED, "싫어요를 성공적으로 접수했습니다.", null));
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<ResponseDTO<RecordDTO>> getRecord(@PathVariable long postId,
+        HttpSession session) {
+        long memberId = (long) session.getAttribute("MEMBER");
+        log.info("getRecord: " + postId + "(postId) + " + memberId + "(memberId)");
+        return ResponseEntity.status(HttpStatus.OK).body(
+            ResponseDTO.res(HttpStatus.OK, "좋아요/싫어요를 성공적으로 조회했습니다.",
+                recordService.getRecord(memberId, postId)));
     }
 
     @DeleteMapping

--- a/src/main/java/com/fasttime/domain/record/controller/RecordRestControllerAdvice.java
+++ b/src/main/java/com/fasttime/domain/record/controller/RecordRestControllerAdvice.java
@@ -1,0 +1,21 @@
+package com.fasttime.domain.record.controller;
+
+import com.fasttime.domain.record.exception.DuplicateRecordException;
+import com.fasttime.global.util.ResponseDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+class RecordRestControllerAdvice {
+
+    @ExceptionHandler
+    ResponseEntity<ResponseDTO<Object>> duplicateRecordException(DuplicateRecordException e) {
+        log.error("DuplicateRecordException: " + e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ResponseDTO.res(HttpStatus.BAD_REQUEST, e.getMessage()));
+    }
+}

--- a/src/main/java/com/fasttime/domain/record/dto/RecordDTO.java
+++ b/src/main/java/com/fasttime/domain/record/dto/RecordDTO.java
@@ -10,5 +10,5 @@ public class RecordDTO {
     private Long id;
     private Long memberId;
     private Long postId;
-    private boolean isLike;
+    private Boolean isLike;
 }

--- a/src/main/java/com/fasttime/domain/record/dto/RecordDTO.java
+++ b/src/main/java/com/fasttime/domain/record/dto/RecordDTO.java
@@ -1,7 +1,5 @@
 package com.fasttime.domain.record.dto;
 
-import com.fasttime.domain.member.entity.Member;
-import com.fasttime.domain.post.entity.Post;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,7 +8,7 @@ import lombok.Getter;
 public class RecordDTO {
 
     private Long id;
-    private Member member;
-    private Post post;
+    private Long memberId;
+    private Long postId;
     private boolean isLike;
 }

--- a/src/main/java/com/fasttime/domain/record/dto/RecordDTO.java
+++ b/src/main/java/com/fasttime/domain/record/dto/RecordDTO.java
@@ -1,0 +1,16 @@
+package com.fasttime.domain.record.dto;
+
+import com.fasttime.domain.member.entity.Member;
+import com.fasttime.domain.post.entity.Post;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class RecordDTO {
+
+    private Long id;
+    private Member member;
+    private Post post;
+    private boolean isLike;
+}

--- a/src/main/java/com/fasttime/domain/record/dto/request/CreateRecordRequestDTO.java
+++ b/src/main/java/com/fasttime/domain/record/dto/request/CreateRecordRequestDTO.java
@@ -1,0 +1,20 @@
+package com.fasttime.domain.record.dto.request;
+
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateRecordRequestDTO {
+
+    @NotNull(message = "게시글 ID를 입력하세요.")
+    private Long postId;
+
+    @NotNull(message = "회원 ID를 입력하세요.")
+    private Long memberId;
+}

--- a/src/main/java/com/fasttime/domain/record/dto/request/DeleteRecordRequestDTO.java
+++ b/src/main/java/com/fasttime/domain/record/dto/request/DeleteRecordRequestDTO.java
@@ -1,0 +1,20 @@
+package com.fasttime.domain.record.dto.request;
+
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteRecordRequestDTO {
+
+    @NotNull(message = "게시글 ID를 입력하세요.")
+    private Long postId;
+
+    @NotNull(message = "회원 ID를 입력하세요.")
+    private Long memberId;
+}

--- a/src/main/java/com/fasttime/domain/record/entity/Record.java
+++ b/src/main/java/com/fasttime/domain/record/entity/Record.java
@@ -11,6 +11,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
@@ -35,4 +36,12 @@ public class Record extends BaseTimeEntity {
     @Comment("좋아요 = 1, 싫어요 = 0")
     @Column(name = "type")
     private boolean isLike;
+
+    @Builder
+    public Record(Long id, Member member, Post post, boolean isLike) {
+        this.id = id;
+        this.member = member;
+        this.post = post;
+        this.isLike = isLike;
+    }
 }

--- a/src/main/java/com/fasttime/domain/record/entity/Record.java
+++ b/src/main/java/com/fasttime/domain/record/entity/Record.java
@@ -2,6 +2,7 @@ package com.fasttime.domain.record.entity;
 
 import com.fasttime.domain.member.entity.Member;
 import com.fasttime.domain.post.entity.Post;
+import com.fasttime.domain.record.dto.RecordDTO;
 import com.fasttime.global.common.BaseTimeEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -43,5 +44,10 @@ public class Record extends BaseTimeEntity {
         this.member = member;
         this.post = post;
         this.isLike = isLike;
+    }
+
+    public RecordDTO toDTO() {
+        return RecordDTO.builder().id(this.id).postId(this.post.getId())
+            .memberId(this.member.getId()).isLike(this.isLike).build();
     }
 }

--- a/src/main/java/com/fasttime/domain/record/exception/DuplicateRecordException.java
+++ b/src/main/java/com/fasttime/domain/record/exception/DuplicateRecordException.java
@@ -1,0 +1,11 @@
+package com.fasttime.domain.record.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicateRecordException extends ApplicationException {
+
+    public DuplicateRecordException(String message) {
+        super(HttpStatus.BAD_REQUEST, message);
+    }
+}

--- a/src/main/java/com/fasttime/domain/record/exception/RecordNotFoundException.java
+++ b/src/main/java/com/fasttime/domain/record/exception/RecordNotFoundException.java
@@ -1,0 +1,13 @@
+package com.fasttime.domain.record.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import org.springframework.http.HttpStatus;
+
+public class RecordNotFoundException extends ApplicationException {
+
+    private static final HttpStatus httpStatus = HttpStatus.NOT_FOUND;
+
+    public RecordNotFoundException() {
+        super(httpStatus, "존재하지 않는 좋아요/싫어요 입니다.");
+    }
+}

--- a/src/main/java/com/fasttime/domain/record/service/RecordService.java
+++ b/src/main/java/com/fasttime/domain/record/service/RecordService.java
@@ -39,7 +39,7 @@ public class RecordService {
 
     public RecordDTO getRecord(long memberId, long postId) {
         Optional<Record> record = recordRepository.findByMemberIdAndPostId(memberId, postId);
-        return record.map(Record::toDTO).orElse(null);
+        return record.map(Record::toDTO).orElse(RecordDTO.builder().id(null).memberId(null).postId(null).isLike(null).build());
     }
 
     public void deleteRecord(DeleteRecordRequestDTO req) {

--- a/src/main/java/com/fasttime/domain/record/service/RecordService.java
+++ b/src/main/java/com/fasttime/domain/record/service/RecordService.java
@@ -1,0 +1,55 @@
+package com.fasttime.domain.record.service;
+
+import com.fasttime.domain.member.entity.Member;
+import com.fasttime.domain.member.service.MemberService;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
+import com.fasttime.domain.post.entity.Post;
+import com.fasttime.domain.post.service.PostQueryService;
+import com.fasttime.domain.record.dto.request.CreateRecordRequestDTO;
+import com.fasttime.domain.record.dto.request.DeleteRecordRequestDTO;
+import com.fasttime.domain.record.entity.Record;
+import com.fasttime.domain.record.exception.DuplicateRecordException;
+import com.fasttime.domain.record.exception.RecordNotFoundException;
+import com.fasttime.domain.record.repository.RecordRepository;
+import java.util.Optional;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RecordService {
+
+    private final RecordRepository recordRepository;
+    private final PostQueryService postQueryService;
+    private final MemberService memberService;
+
+    public void createRecord(CreateRecordRequestDTO req, boolean isLike) {
+        PostDetailResponseDto postResponse = postQueryService.findById(req.getPostId());
+        Member member = memberService.getMember(req.getMemberId());
+        checkDuplicateRecord(member.getId(), postResponse.getId(), isLike);
+        recordRepository.save(
+            Record.builder().member(member).post(Post.builder().id(postResponse.getId()).build())
+                .isLike(isLike).build());
+    }
+
+    public void deleteRecord(DeleteRecordRequestDTO req) {
+        Record record = recordRepository.findByMemberIdAndPostId(req.getMemberId(), req.getPostId())
+            .orElseThrow(RecordNotFoundException::new);
+        recordRepository.delete(record);
+    }
+
+    private void checkDuplicateRecord(long memberId, long postId, boolean isLike) {
+        Optional<Record> record = recordRepository.findByMemberIdAndPostId(memberId, postId);
+        if (record.isPresent()) {
+            if (record.get().isLike() == isLike) {
+                throw new DuplicateRecordException("중복된 요청입니다.");
+            } else {
+                throw new DuplicateRecordException("한 게시글에 대해 좋아요와 싫어요를 모두 할 수는 없습니다.");
+            }
+        }
+    }
+}

--- a/src/main/java/com/fasttime/domain/record/service/RecordService.java
+++ b/src/main/java/com/fasttime/domain/record/service/RecordService.java
@@ -5,6 +5,7 @@ import com.fasttime.domain.member.service.MemberService;
 import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.service.PostQueryService;
+import com.fasttime.domain.record.dto.RecordDTO;
 import com.fasttime.domain.record.dto.request.CreateRecordRequestDTO;
 import com.fasttime.domain.record.dto.request.DeleteRecordRequestDTO;
 import com.fasttime.domain.record.entity.Record;
@@ -34,6 +35,11 @@ public class RecordService {
         recordRepository.save(
             Record.builder().member(member).post(Post.builder().id(postResponse.getId()).build())
                 .isLike(isLike).build());
+    }
+
+    public RecordDTO getRecord(long memberId, long postId) {
+        Optional<Record> record = recordRepository.findByMemberIdAndPostId(memberId, postId);
+        return record.map(Record::toDTO).orElse(null);
     }
 
     public void deleteRecord(DeleteRecordRequestDTO req) {

--- a/src/test/java/com/fasttime/domain/record/docs/RecordControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/record/docs/RecordControllerDocsTest.java
@@ -1,0 +1,124 @@
+package com.fasttime.domain.record.docs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasttime.docs.RestDocsSupport;
+import com.fasttime.domain.record.controller.RecordRestController;
+import com.fasttime.domain.record.dto.request.CreateRecordRequestDTO;
+import com.fasttime.domain.record.dto.request.DeleteRecordRequestDTO;
+import com.fasttime.domain.record.service.RecordService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.constraints.ConstraintDescriptions;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+public class RecordControllerDocsTest extends RestDocsSupport {
+
+    private final RecordService recordService = mock(RecordService.class);
+
+    @Override
+    public Object initController() {
+        return new RecordRestController(recordService);
+    }
+
+    ConstraintDescriptions createRecordRequestConstraints = new ConstraintDescriptions(
+        CreateRecordRequestDTO.class);
+    ConstraintDescriptions deleteRecordRequestConstraints = new ConstraintDescriptions(
+        DeleteRecordRequestDTO.class);
+
+    @DisplayName("좋아요 등록 API 문서화")
+    @Test
+    void createLike() throws Exception {
+        // given
+        CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L).postId(1L)
+            .build();
+        doNothing().when(recordService)
+            .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
+        String json = new ObjectMapper().writeValueAsString(request);
+
+        // when, then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/record/like").content(json)
+            .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isCreated()).andDo(
+            document("record-like-create", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()), requestFields(
+                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자").attributes(
+                        key("constraints").value(
+                            createRecordRequestConstraints.descriptionsForProperty("memberId"))),
+                    fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자").attributes(
+                        key("constraints").value(
+                            createRecordRequestConstraints.descriptionsForProperty("postId")))),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+                    fieldWithPath("data").type(JsonFieldType.NULL).description("응답데이터"))));
+    }
+
+    @DisplayName("싫어요 등록 API 문서화")
+    @Test
+    void createHate() throws Exception {
+        // given
+        CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L).postId(1L)
+            .build();
+        doNothing().when(recordService)
+            .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
+        String json = new ObjectMapper().writeValueAsString(request);
+
+        // when, then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/record/hate").content(json)
+            .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isCreated()).andDo(
+            document("record-hate-create", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()), requestFields(
+                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자").attributes(
+                        key("constraints").value(
+                            createRecordRequestConstraints.descriptionsForProperty("memberId"))),
+                    fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자").attributes(
+                        key("constraints").value(
+                            createRecordRequestConstraints.descriptionsForProperty("postId")))),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+                    fieldWithPath("data").type(JsonFieldType.NULL).description("응답데이터"))));
+    }
+
+    @DisplayName("좋아요/싫어요 취소 API 문서화")
+    @Test
+    void deleteRecord() throws Exception {
+        // given
+        DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().memberId(1L).postId(1L)
+            .build();
+        doNothing().when(recordService).deleteRecord(any(DeleteRecordRequestDTO.class));
+        String json = new ObjectMapper().writeValueAsString(request);
+
+        // when, then
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/record").content(json)
+            .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk()).andDo(
+            document("record-delete", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()), requestFields(
+                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자").attributes(
+                        key("constraints").value(
+                            deleteRecordRequestConstraints.descriptionsForProperty("memberId"))),
+                    fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자").attributes(
+                        key("constraints").value(
+                            deleteRecordRequestConstraints.descriptionsForProperty("postId")))),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+                    fieldWithPath("data").type(JsonFieldType.NULL).description("응답데이터"))));
+    }
+}

--- a/src/test/java/com/fasttime/domain/record/docs/RecordControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/record/docs/RecordControllerDocsTest.java
@@ -2,6 +2,7 @@ package com.fasttime.domain.record.docs;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -11,20 +12,24 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.snippet.Attributes.key;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasttime.docs.RestDocsSupport;
 import com.fasttime.domain.record.controller.RecordRestController;
+import com.fasttime.domain.record.dto.RecordDTO;
 import com.fasttime.domain.record.dto.request.CreateRecordRequestDTO;
 import com.fasttime.domain.record.dto.request.DeleteRecordRequestDTO;
 import com.fasttime.domain.record.service.RecordService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.restdocs.constraints.ConstraintDescriptions;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -57,11 +62,11 @@ public class RecordControllerDocsTest extends RestDocsSupport {
             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isCreated()).andDo(
             document("record-like-create", preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()), requestFields(
-                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자").attributes(
-                        key("constraints").value(
+                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자")
+                        .attributes(key("constraints").value(
                             createRecordRequestConstraints.descriptionsForProperty("memberId"))),
-                    fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자").attributes(
-                        key("constraints").value(
+                    fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자")
+                        .attributes(key("constraints").value(
                             createRecordRequestConstraints.descriptionsForProperty("postId")))),
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
@@ -84,16 +89,46 @@ public class RecordControllerDocsTest extends RestDocsSupport {
             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isCreated()).andDo(
             document("record-hate-create", preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()), requestFields(
-                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자").attributes(
-                        key("constraints").value(
+                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자")
+                        .attributes(key("constraints").value(
                             createRecordRequestConstraints.descriptionsForProperty("memberId"))),
-                    fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자").attributes(
-                        key("constraints").value(
+                    fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자")
+                        .attributes(key("constraints").value(
                             createRecordRequestConstraints.descriptionsForProperty("postId")))),
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
                     fieldWithPath("data").type(JsonFieldType.NULL).description("응답데이터"))));
+    }
+
+    @DisplayName("좋아요/싫어요 조회 API 문서화")
+    @Test
+    void getRecord() throws Exception {
+        // given
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("MEMBER", 1L);
+        RecordDTO recordDTO = RecordDTO.builder().id(1L).memberId(1L).postId(1L).isLike(true)
+            .build();
+        given(recordService.getRecord(any(Long.class), any(Long.class))).willReturn(recordDTO);
+
+        // when, then
+        mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/api/v1/record/{postId}", 1L).session(session))
+            .andExpect(status().isOk()).andDo(
+                document("record-get", preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(parameterWithName("postId").description("게시글 식별자")), responseFields(
+                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답데이터"),
+                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).optional()
+                            .description("좋아요/싫어요 식별자"),
+                        fieldWithPath("data.memberId").type(JsonFieldType.NUMBER).optional()
+                            .description("회원 식별자"),
+                        fieldWithPath("data.postId").type(JsonFieldType.NUMBER).optional()
+                            .description("게시글 식별자"),
+                        fieldWithPath("data.like").type(JsonFieldType.BOOLEAN)
+                            .description("좋아요(1), 싫어요(0)"))));
     }
 
     @DisplayName("좋아요/싫어요 취소 API 문서화")
@@ -110,11 +145,11 @@ public class RecordControllerDocsTest extends RestDocsSupport {
             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk()).andDo(
             document("record-delete", preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()), requestFields(
-                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자").attributes(
-                        key("constraints").value(
+                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자")
+                        .attributes(key("constraints").value(
                             deleteRecordRequestConstraints.descriptionsForProperty("memberId"))),
-                    fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자").attributes(
-                        key("constraints").value(
+                    fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자")
+                        .attributes(key("constraints").value(
                             deleteRecordRequestConstraints.descriptionsForProperty("postId")))),
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),

--- a/src/test/java/com/fasttime/domain/record/docs/RecordControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/record/docs/RecordControllerDocsTest.java
@@ -127,7 +127,7 @@ public class RecordControllerDocsTest extends RestDocsSupport {
                             .description("회원 식별자"),
                         fieldWithPath("data.postId").type(JsonFieldType.NUMBER).optional()
                             .description("게시글 식별자"),
-                        fieldWithPath("data.like").type(JsonFieldType.BOOLEAN)
+                        fieldWithPath("data.isLike").type(JsonFieldType.BOOLEAN)
                             .description("좋아요(1), 싫어요(0)"))));
     }
 

--- a/src/test/java/com/fasttime/domain/record/unit/controller/RecordRestControllerTest.java
+++ b/src/test/java/com/fasttime/domain/record/unit/controller/RecordRestControllerTest.java
@@ -2,8 +2,10 @@ package com.fasttime.domain.record.unit.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -11,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasttime.domain.record.controller.RecordRestController;
+import com.fasttime.domain.record.dto.RecordDTO;
 import com.fasttime.domain.record.dto.request.CreateRecordRequestDTO;
 import com.fasttime.domain.record.dto.request.DeleteRecordRequestDTO;
 import com.fasttime.domain.record.service.RecordService;
@@ -21,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(RecordRestController.class)
@@ -40,8 +44,8 @@ public class RecordRestControllerTest {
         @DisplayName("게시글을 좋아요 할 수 있다.")
         void _willSuccess() throws Exception {
             // given
-            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L).postId(1L)
-                .build();
+            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L)
+                .postId(1L).build();
             doNothing().when(recordService)
                 .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
             String json = new ObjectMapper().writeValueAsString(request);
@@ -62,8 +66,7 @@ public class RecordRestControllerTest {
             void null_willFail() throws Exception {
                 // given
                 CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L)
-                    .postId(null)
-                    .build();
+                    .postId(null).build();
                 doNothing().when(recordService)
                     .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
                 String json = new ObjectMapper().writeValueAsString(request);
@@ -84,8 +87,7 @@ public class RecordRestControllerTest {
             void null_willFail() throws Exception {
                 // given
                 CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(null)
-                    .postId(1L)
-                    .build();
+                    .postId(1L).build();
                 doNothing().when(recordService)
                     .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
                 String json = new ObjectMapper().writeValueAsString(request);
@@ -106,8 +108,8 @@ public class RecordRestControllerTest {
         @DisplayName("게시글을 싫어요 할 수 있다.")
         void _willSuccess() throws Exception {
             // given
-            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L).postId(1L)
-                .build();
+            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L)
+                .postId(1L).build();
             doNothing().when(recordService)
                 .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
             String json = new ObjectMapper().writeValueAsString(request);
@@ -128,8 +130,7 @@ public class RecordRestControllerTest {
             void null_willFail() throws Exception {
                 // given
                 CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L)
-                    .postId(null)
-                    .build();
+                    .postId(null).build();
                 doNothing().when(recordService)
                     .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
                 String json = new ObjectMapper().writeValueAsString(request);
@@ -150,8 +151,7 @@ public class RecordRestControllerTest {
             void null_willFail() throws Exception {
                 // given
                 CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(null)
-                    .postId(1L)
-                    .build();
+                    .postId(1L).build();
                 doNothing().when(recordService)
                     .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
                 String json = new ObjectMapper().writeValueAsString(request);
@@ -165,6 +165,31 @@ public class RecordRestControllerTest {
     }
 
     @Nested
+    @DisplayName("getRecord()는")
+    class Context_getRecord {
+
+        @Test
+        @DisplayName("좋아요/싫어요 데이터를 불러올 수 있다.")
+        void _willSuccess() throws Exception {
+            // given
+            MockHttpSession session = new MockHttpSession();
+            session.setAttribute("MEMBER", 1L);
+            RecordDTO recordDTO = RecordDTO.builder().id(1L).memberId(1L).postId(1L).isLike(true)
+                .build();
+            given(recordService.getRecord(any(Long.class), any(Long.class))).willReturn(recordDTO);
+
+            // when, then
+            mockMvc.perform(get("/api/v1/record/{postId}", 1L).session(session)
+                    .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.data.id").exists())
+                .andExpect(jsonPath("$.data.memberId").exists())
+                .andExpect(jsonPath("$.data.postId").exists())
+                .andExpect(jsonPath("$.data.isLike").exists()).andDo(print());
+        }
+    }
+
+    @Nested
     @DisplayName("deleteRecord()는")
     class Context_deleteRecord {
 
@@ -172,8 +197,8 @@ public class RecordRestControllerTest {
         @DisplayName("게시글 좋아요(싫어요)를 취소할 수 있다.")
         void _willSuccess() throws Exception {
             // given
-            DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().memberId(1L).postId(1L)
-                .build();
+            DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().memberId(1L)
+                .postId(1L).build();
             doNothing().when(recordService).deleteRecord(any(DeleteRecordRequestDTO.class));
             String json = new ObjectMapper().writeValueAsString(request);
 
@@ -193,15 +218,15 @@ public class RecordRestControllerTest {
             void null_willFail() throws Exception {
                 // given
                 DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().memberId(1L)
-                    .postId(null)
-                    .build();
+                    .postId(null).build();
                 doNothing().when(recordService).deleteRecord(any(DeleteRecordRequestDTO.class));
                 String json = new ObjectMapper().writeValueAsString(request);
 
                 // when, then
-                mockMvc.perform(delete("/api/v1/record").content(json)
-                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+                mockMvc.perform(
+                        delete("/api/v1/record").content(json).contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message").exists())
+                    .andDo(print());
             }
         }
 
@@ -214,15 +239,15 @@ public class RecordRestControllerTest {
             void null_willFail() throws Exception {
                 // given
                 DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().memberId(null)
-                    .postId(1L)
-                    .build();
+                    .postId(1L).build();
                 doNothing().when(recordService).deleteRecord(any(DeleteRecordRequestDTO.class));
                 String json = new ObjectMapper().writeValueAsString(request);
 
                 // when, then
-                mockMvc.perform(delete("/api/v1/record").content(json)
-                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+                mockMvc.perform(
+                        delete("/api/v1/record").content(json).contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message").exists())
+                    .andDo(print());
             }
         }
     }

--- a/src/test/java/com/fasttime/domain/record/unit/controller/RecordRestControllerTest.java
+++ b/src/test/java/com/fasttime/domain/record/unit/controller/RecordRestControllerTest.java
@@ -1,0 +1,229 @@
+package com.fasttime.domain.record.unit.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasttime.domain.record.controller.RecordRestController;
+import com.fasttime.domain.record.dto.request.CreateRecordRequestDTO;
+import com.fasttime.domain.record.dto.request.DeleteRecordRequestDTO;
+import com.fasttime.domain.record.service.RecordService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(RecordRestController.class)
+public class RecordRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    RecordService recordService;
+
+    @Nested
+    @DisplayName("createLike()는")
+    class Context_createLike {
+
+        @Test
+        @DisplayName("게시글을 좋아요 할 수 있다.")
+        void _willSuccess() throws Exception {
+            // given
+            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L).postId(1L)
+                .build();
+            doNothing().when(recordService)
+                .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
+            String json = new ObjectMapper().writeValueAsString(request);
+
+            // when, then
+            mockMvc.perform(
+                    post("/api/v1/record/like").content(json).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated()).andExpect(jsonPath("$.message").exists())
+                .andDo(print());
+        }
+
+        @Nested
+        @DisplayName("postId가 ")
+        class Element_postId {
+
+            @Test
+            @DisplayName("null일 경우 좋아요 할 수 없다.")
+            void null_willFail() throws Exception {
+                // given
+                CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L)
+                    .postId(null)
+                    .build();
+                doNothing().when(recordService)
+                    .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
+                String json = new ObjectMapper().writeValueAsString(request);
+
+                // when, then
+                mockMvc.perform(post("/api/v1/record/like").content(json)
+                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+            }
+        }
+
+        @Nested
+        @DisplayName("memberId가 ")
+        class Element_memberId {
+
+            @Test
+            @DisplayName("null일 경우 좋아요 할 수 없다.")
+            void null_willFail() throws Exception {
+                // given
+                CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(null)
+                    .postId(1L)
+                    .build();
+                doNothing().when(recordService)
+                    .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
+                String json = new ObjectMapper().writeValueAsString(request);
+
+                // when, then
+                mockMvc.perform(post("/api/v1/record/like").content(json)
+                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("createHate()는")
+    class Context_createHate {
+
+        @Test
+        @DisplayName("게시글을 싫어요 할 수 있다.")
+        void _willSuccess() throws Exception {
+            // given
+            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L).postId(1L)
+                .build();
+            doNothing().when(recordService)
+                .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
+            String json = new ObjectMapper().writeValueAsString(request);
+
+            // when, then
+            mockMvc.perform(
+                    post("/api/v1/record/hate").content(json).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated()).andExpect(jsonPath("$.message").exists())
+                .andDo(print());
+        }
+
+        @Nested
+        @DisplayName("postId가 ")
+        class Element_postId {
+
+            @Test
+            @DisplayName("null일 경우 싫어요 할 수 없다.")
+            void null_willFail() throws Exception {
+                // given
+                CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L)
+                    .postId(null)
+                    .build();
+                doNothing().when(recordService)
+                    .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
+                String json = new ObjectMapper().writeValueAsString(request);
+
+                // when, then
+                mockMvc.perform(post("/api/v1/record/hate").content(json)
+                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+            }
+        }
+
+        @Nested
+        @DisplayName("memberId가 ")
+        class Element_memberId {
+
+            @Test
+            @DisplayName("null일 경우 싫어요 할 수 없다.")
+            void null_willFail() throws Exception {
+                // given
+                CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(null)
+                    .postId(1L)
+                    .build();
+                doNothing().when(recordService)
+                    .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
+                String json = new ObjectMapper().writeValueAsString(request);
+
+                // when, then
+                mockMvc.perform(post("/api/v1/record/hate").content(json)
+                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteRecord()는")
+    class Context_deleteRecord {
+
+        @Test
+        @DisplayName("게시글 좋아요(싫어요)를 취소할 수 있다.")
+        void _willSuccess() throws Exception {
+            // given
+            DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().memberId(1L).postId(1L)
+                .build();
+            doNothing().when(recordService).deleteRecord(any(DeleteRecordRequestDTO.class));
+            String json = new ObjectMapper().writeValueAsString(request);
+
+            // when, then
+            mockMvc.perform(
+                    delete("/api/v1/record").content(json).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.message").exists())
+                .andDo(print());
+        }
+
+        @Nested
+        @DisplayName("postId가 ")
+        class Element_postId {
+
+            @Test
+            @DisplayName("null일 경우 취소할 수 없다.")
+            void null_willFail() throws Exception {
+                // given
+                DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().memberId(1L)
+                    .postId(null)
+                    .build();
+                doNothing().when(recordService).deleteRecord(any(DeleteRecordRequestDTO.class));
+                String json = new ObjectMapper().writeValueAsString(request);
+
+                // when, then
+                mockMvc.perform(delete("/api/v1/record").content(json)
+                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+            }
+        }
+
+        @Nested
+        @DisplayName("memberId가 ")
+        class Element_memberId {
+
+            @Test
+            @DisplayName("null일 경우 취소할 수 없다.")
+            void null_willFail() throws Exception {
+                // given
+                DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().memberId(null)
+                    .postId(1L)
+                    .build();
+                doNothing().when(recordService).deleteRecord(any(DeleteRecordRequestDTO.class));
+                String json = new ObjectMapper().writeValueAsString(request);
+
+                // when, then
+                mockMvc.perform(delete("/api/v1/record").content(json)
+                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+            }
+        }
+    }
+}

--- a/src/test/java/com/fasttime/domain/record/unit/entity/RecordTest.java
+++ b/src/test/java/com/fasttime/domain/record/unit/entity/RecordTest.java
@@ -1,0 +1,27 @@
+package com.fasttime.domain.record.unit.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasttime.domain.member.entity.Member;
+import com.fasttime.domain.post.entity.Post;
+import com.fasttime.domain.record.entity.Record;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class RecordTest {
+
+    @DisplayName("좋아요/싫어요 Entity 를 생성할 수 있다.")
+    @Test
+    void create_record_willSuccess() {
+        // given
+        Post post = Post.builder().id(0L).build();
+        Member member = Member.builder().id(0L).build();
+
+        // when
+        Record record = Record.builder().id(0L).post(post).member(member).isLike(true).build();
+
+        // then
+        assertThat(record).extracting("id", "member", "post", "isLike")
+            .containsExactly(0L, member, post, true);
+    }
+}

--- a/src/test/java/com/fasttime/domain/record/unit/service/RecordServiceTest.java
+++ b/src/test/java/com/fasttime/domain/record/unit/service/RecordServiceTest.java
@@ -185,7 +185,7 @@ public class RecordServiceTest {
 
             // then
             assertThat(result).extracting("id", "postId", "memberId", "isLike")
-                .containsExactly(null, null, null, false);
+                .containsExactly(null, null, null, null);
 
             verify(recordRepository, times(1)).findByMemberIdAndPostId(any(Long.class),
                 any(Long.class));

--- a/src/test/java/com/fasttime/domain/record/unit/service/RecordServiceTest.java
+++ b/src/test/java/com/fasttime/domain/record/unit/service/RecordServiceTest.java
@@ -1,0 +1,187 @@
+package com.fasttime.domain.record.unit.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasttime.domain.member.entity.Member;
+import com.fasttime.domain.member.service.MemberService;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
+import com.fasttime.domain.post.entity.Post;
+import com.fasttime.domain.post.service.PostQueryService;
+import com.fasttime.domain.record.dto.request.CreateRecordRequest;
+import com.fasttime.domain.record.dto.request.DeleteRecordRequest;
+import com.fasttime.domain.record.entity.Record;
+import com.fasttime.domain.record.exception.DuplicateRecordException;
+import com.fasttime.domain.record.exception.RecordNotFoundException;
+import com.fasttime.domain.record.repository.RecordRepository;
+import com.fasttime.domain.record.service.RecordService;
+import com.fasttime.domain.report.exception.DuplicateReportException;
+import java.util.Optional;
+import javax.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+public class RecordServiceTest {
+
+    @InjectMocks
+    private RecordService recordService;
+
+    @Mock
+    private RecordRepository recordRepository;
+
+    @Mock
+    private PostQueryService postQueryService;
+
+    @Mock
+    private MemberService memberService;
+
+    @Nested
+    @DisplayName("createRecord()는 ")
+    class Context_createRecord {
+
+        @Test
+        @DisplayName("게시글을 좋아요 할 수 있다.")
+        void like_willSuccess() {
+            // given
+            CreateRecordRequest request = CreateRecordRequest.builder().memberId(1L).postId(1L)
+                .build();
+            PostDetailResponseDto post = PostDetailResponseDto.builder().id(1L).build();
+            Member member = Member.builder().id(1L).build();
+            Optional<Record> record = Optional.empty();
+
+            given(postQueryService.findById(any(Long.class))).willReturn(post);
+            given(memberService.getMember(any(Long.class))).willReturn(member);
+            given(recordRepository.findByMemberIdAndPostId(any(long.class),
+                any(long.class))).willReturn(record);
+
+            // when
+            recordService.createRecord(request, true);
+
+            // then
+            verify(recordRepository, times(1)).save(any(Record.class));
+        }
+
+        @Test
+        @DisplayName("게시글을 싫어요 할 수 있다.")
+        void hate_willSuccess() {
+            // given
+            CreateRecordRequest request = CreateRecordRequest.builder().memberId(1L).postId(1L)
+                .build();
+            PostDetailResponseDto post = PostDetailResponseDto.builder().id(1L).build();
+            Member member = Member.builder().id(1L).build();
+            Optional<Record> record = Optional.empty();
+
+            given(postQueryService.findById(any(Long.class))).willReturn(post);
+            given(memberService.getMember(any(Long.class))).willReturn(member);
+            given(recordRepository.findByMemberIdAndPostId(any(long.class),
+                any(long.class))).willReturn(record);
+
+            // when
+            recordService.createRecord(request, false);
+
+            // then
+            verify(recordRepository, times(1)).save(any(Record.class));
+        }
+
+        @Test
+        @DisplayName("이미 좋아요(싫어요)를 한 게시글에 다시 좋아요(싫어요)를 등록할 수 없다.")
+        void duplicateRecord1_willFail() {
+            // given
+            CreateRecordRequest request = CreateRecordRequest.builder().memberId(1L).postId(1L)
+                .build();
+            PostDetailResponseDto post = PostDetailResponseDto.builder().id(1L).build();
+            Member member = Member.builder().id(1L).build();
+            Optional<Record> record = Optional.of(Record.builder().member(member).post(
+                Post.builder().id(post.getId()).build()).isLike(true).build());
+
+            given(postQueryService.findById(any(Long.class))).willReturn(post);
+            given(memberService.getMember(any(Long.class))).willReturn(member);
+            given(recordRepository.findByMemberIdAndPostId(any(long.class),
+                any(long.class))).willReturn(record);
+
+            // when, then
+            Throwable exception = assertThrows(DuplicateRecordException.class, () -> {
+                recordService.createRecord(request, true);
+            });
+            assertEquals("중복된 요청입니다.", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("좋아요와 싫어요를 중복으로 등록할 수 없다.")
+        void duplicateRecord2_willFail() {
+            // given
+            CreateRecordRequest request = CreateRecordRequest.builder().memberId(1L).postId(1L)
+                .build();
+            PostDetailResponseDto post = PostDetailResponseDto.builder().id(1L).build();
+            Member member = Member.builder().id(1L).build();
+            Optional<Record> record = Optional.of(Record.builder().member(member).post(
+                Post.builder().id(post.getId()).build()).isLike(false).build());
+
+            given(postQueryService.findById(any(Long.class))).willReturn(post);
+            given(memberService.getMember(any(Long.class))).willReturn(member);
+            given(recordRepository.findByMemberIdAndPostId(any(long.class),
+                any(long.class))).willReturn(record);
+
+            // when, then
+            Throwable exception = assertThrows(DuplicateRecordException.class, () -> {
+                recordService.createRecord(request, true);
+            });
+            assertEquals("한 게시글에 대해 좋아요와 싫어요를 모두 할 수는 없습니다.", exception.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteRecord()는 ")
+    class Context_deleteRecord {
+
+        @Test
+        @DisplayName("게시글 좋아요/싫어요를 취소할 수 있다.")
+        void _willSuccess() {
+            // given
+            DeleteRecordRequest request = DeleteRecordRequest.builder().memberId(1L).postId(1L)
+                .build();
+            Post post = Post.builder().id(1L).build();
+            Member member = Member.builder().id(1L).build();
+            Optional<Record> record = Optional.of(
+                Record.builder().id(1L).member(member).post(post).isLike(true).build());
+
+            given(recordRepository.findByMemberIdAndPostId(any(long.class),
+                any(long.class))).willReturn(record);
+
+            // when
+            recordService.deleteRecord(request);
+
+            // then
+            verify(recordRepository, times(1)).delete(any(Record.class));
+        }
+
+        @Test
+        @DisplayName("게시글 좋아요/싫어요 한 적이 없다면 좋아요/싫어요를 취소할 수 없다.")
+        void recordNotFound_willSuccess() {
+            // given
+            DeleteRecordRequest request = DeleteRecordRequest.builder().memberId(1L).postId(1L)
+                .build();
+            Optional<Record> record = Optional.empty();
+
+            given(recordRepository.findByMemberIdAndPostId(any(long.class),
+                any(long.class))).willReturn(record);
+
+            // when, then
+            Throwable exception = assertThrows(RecordNotFoundException.class, () -> {
+                recordService.deleteRecord(request);
+            });
+            assertEquals("존재하지 않는 좋아요/싫어요 입니다.", exception.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/fasttime/domain/record/unit/service/RecordServiceTest.java
+++ b/src/test/java/com/fasttime/domain/record/unit/service/RecordServiceTest.java
@@ -12,14 +12,13 @@ import com.fasttime.domain.member.service.MemberService;
 import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.service.PostQueryService;
-import com.fasttime.domain.record.dto.request.CreateRecordRequest;
-import com.fasttime.domain.record.dto.request.DeleteRecordRequest;
+import com.fasttime.domain.record.dto.request.CreateRecordRequestDTO;
+import com.fasttime.domain.record.dto.request.DeleteRecordRequestDTO;
 import com.fasttime.domain.record.entity.Record;
 import com.fasttime.domain.record.exception.DuplicateRecordException;
 import com.fasttime.domain.record.exception.RecordNotFoundException;
 import com.fasttime.domain.record.repository.RecordRepository;
 import com.fasttime.domain.record.service.RecordService;
-import com.fasttime.domain.report.exception.DuplicateReportException;
 import java.util.Optional;
 import javax.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
@@ -54,7 +53,7 @@ public class RecordServiceTest {
         @DisplayName("게시글을 좋아요 할 수 있다.")
         void like_willSuccess() {
             // given
-            CreateRecordRequest request = CreateRecordRequest.builder().memberId(1L).postId(1L)
+            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L).postId(1L)
                 .build();
             PostDetailResponseDto post = PostDetailResponseDto.builder().id(1L).build();
             Member member = Member.builder().id(1L).build();
@@ -76,7 +75,7 @@ public class RecordServiceTest {
         @DisplayName("게시글을 싫어요 할 수 있다.")
         void hate_willSuccess() {
             // given
-            CreateRecordRequest request = CreateRecordRequest.builder().memberId(1L).postId(1L)
+            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L).postId(1L)
                 .build();
             PostDetailResponseDto post = PostDetailResponseDto.builder().id(1L).build();
             Member member = Member.builder().id(1L).build();
@@ -98,7 +97,7 @@ public class RecordServiceTest {
         @DisplayName("이미 좋아요(싫어요)를 한 게시글에 다시 좋아요(싫어요)를 등록할 수 없다.")
         void duplicateRecord1_willFail() {
             // given
-            CreateRecordRequest request = CreateRecordRequest.builder().memberId(1L).postId(1L)
+            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L).postId(1L)
                 .build();
             PostDetailResponseDto post = PostDetailResponseDto.builder().id(1L).build();
             Member member = Member.builder().id(1L).build();
@@ -121,7 +120,7 @@ public class RecordServiceTest {
         @DisplayName("좋아요와 싫어요를 중복으로 등록할 수 없다.")
         void duplicateRecord2_willFail() {
             // given
-            CreateRecordRequest request = CreateRecordRequest.builder().memberId(1L).postId(1L)
+            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L).postId(1L)
                 .build();
             PostDetailResponseDto post = PostDetailResponseDto.builder().id(1L).build();
             Member member = Member.builder().id(1L).build();
@@ -149,7 +148,7 @@ public class RecordServiceTest {
         @DisplayName("게시글 좋아요/싫어요를 취소할 수 있다.")
         void _willSuccess() {
             // given
-            DeleteRecordRequest request = DeleteRecordRequest.builder().memberId(1L).postId(1L)
+            DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().memberId(1L).postId(1L)
                 .build();
             Post post = Post.builder().id(1L).build();
             Member member = Member.builder().id(1L).build();
@@ -170,7 +169,7 @@ public class RecordServiceTest {
         @DisplayName("게시글 좋아요/싫어요 한 적이 없다면 좋아요/싫어요를 취소할 수 없다.")
         void recordNotFound_willSuccess() {
             // given
-            DeleteRecordRequest request = DeleteRecordRequest.builder().memberId(1L).postId(1L)
+            DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().memberId(1L).postId(1L)
                 .build();
             Optional<Record> record = Optional.empty();
 


### PR DESCRIPTION
## 개발내용
- 게시글 좋아요/싫어요 등록 기능 구현
- 회원이 해당 게시글에 대해 등록한 좋아요/싫어요 조회 기능 구현
- 게시글 좋아요/싫어요 취소 기능 구현

## 필요한 기능
- 좋아요/싫어요 등록 혹은 취소 시 게시글의 likeCount, hateCount 증감
  - 게시글 엔터티의 likeCount, hateCount 값을 변경할 수 있는 메서드가 부재하여 일단 보류해뒀습니다. 
  - 해당 기능을 게시글 담당 자현님이 구현해주시거나, 제가 추가하여 곧 수정할 예정입니다. 