### PR TITLE
[feat] 게시글 좋아요/싫어요 조회 기능 추가

### DIFF
--- a/src/main/java/com/fasttime/domain/record/repository/RecordRepository.java
+++ b/src/main/java/com/fasttime/domain/record/repository/RecordRepository.java
@@ -1,10 +1,12 @@
 package com.fasttime.domain.record.repository;
 
 import com.fasttime.domain.record.entity.Record;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecordRepository extends JpaRepository<Record, Long> {
 
     Optional<Record> findByMemberIdAndPostId(Long memberId, Long postId);
+    Optional<List<Record>> findAllByPostId(long postId);
 }


### PR DESCRIPTION
## 문제 상황
- 게시글 좋아요/싫어요 등록 시 게시글 엔터티 필드를 건드리기 때문에 updateAt이 계속 갱신됨. 
- 게시글 수정이 아닌데 updateAt이 갱신되면 안됨. 

## 해결 방안(개발 내용)
- 게시글 좋아요/싫어요 합계 수정하는 로직 제거
- postId에 대한 좋아요/싫어요 개수 반환하는 메서드 추가