### PR TITLE
[refactor] 좋아요/싫어요 기능 리팩토링

### DIFF
--- a/src/docs/asciidoc/record/record-api.adoc
+++ b/src/docs/asciidoc/record/record-api.adoc
@@ -5,35 +5,20 @@
 :toc: left
 :toclevels: 2
 
-[[Record-Like-Create]]
-== 좋아요 등록
+[[Record-Create]]
+== 좋아요/싫어요 등록
 
-회원이 게시글을 좋아요 하는 API 입니다.
-
-=== HttpRequest
-
-include::{snippets}/record-like-create/http-request.adoc[]
-include::{snippets}/record-like-create/request-fields.adoc[]
-
-=== HttpResponse
-
-include::{snippets}/record-like-create/http-response.adoc[]
-include::{snippets}/record-like-create/response-fields.adoc[]
-
-[[Record-Hate-Create]]
-== 싫어요 등록
-
-회원이 게시글을 싫어요 하는 API 입니다.
+회원이 게시글을 좋아요/싫어요 하는 API 입니다.
 
 === HttpRequest
 
-include::{snippets}/record-hate-create/http-request.adoc[]
-include::{snippets}/record-hate-create/request-fields.adoc[]
+include::{snippets}/record-create/http-request.adoc[]
+include::{snippets}/record-create/request-fields.adoc[]
 
 === HttpResponse
 
-include::{snippets}/record-hate-create/http-response.adoc[]
-include::{snippets}/record-hate-create/response-fields.adoc[]
+include::{snippets}/record-create/http-response.adoc[]
+include::{snippets}/record-create/response-fields.adoc[]
 
 [[Record-Get]]
 == 좋아요/싫어요 조회

--- a/src/main/java/com/fasttime/domain/record/controller/RecordRestController.java
+++ b/src/main/java/com/fasttime/domain/record/controller/RecordRestController.java
@@ -27,40 +27,34 @@ public class RecordRestController {
 
     private final RecordService recordService;
 
-    @PostMapping("/like")
-    public ResponseEntity<ResponseDTO<Void>> createLike(
-        @Valid @RequestBody CreateRecordRequestDTO createRecordRequestDTO) {
-        log.info("CreateRecordRequest: " + createRecordRequestDTO + "(like)");
-        recordService.createRecord(createRecordRequestDTO, true);
+    @PostMapping
+    public ResponseEntity<ResponseDTO<Object>> createLike(
+        @Valid @RequestBody CreateRecordRequestDTO createRecordRequestDTO, HttpSession session) {
+        log.info("CreateRecordRequest: " + createRecordRequestDTO);
+        recordService.createRecord(createRecordRequestDTO, (Long) session.getAttribute("MEMBER"));
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(ResponseDTO.res(HttpStatus.CREATED, "좋아요를 성공적으로 접수했습니다.", null));
-    }
-
-    @PostMapping("/hate")
-    public ResponseEntity<ResponseDTO<RecordDTO>> createHate(
-        @Valid @RequestBody CreateRecordRequestDTO createRecordRequestDTO) {
-        log.info("CreateRecordRequest: " + createRecordRequestDTO + "(hate)");
-        recordService.createRecord(createRecordRequestDTO, false);
-        return ResponseEntity.status(HttpStatus.CREATED)
-            .body(ResponseDTO.res(HttpStatus.CREATED, "싫어요를 성공적으로 접수했습니다.", null));
+            .body(ResponseDTO.res(HttpStatus.CREATED, "좋아요/싫어요를 성공적으로 등록했습니다."));
     }
 
     @GetMapping("/{postId}")
     public ResponseEntity<ResponseDTO<RecordDTO>> getRecord(@PathVariable long postId,
         HttpSession session) {
-        long memberId = (long) session.getAttribute("MEMBER");
-        log.info("getRecord: " + postId + "(postId) + " + memberId + "(memberId)");
+        Long memberId = (Long) session.getAttribute("MEMBER");
+        log.info("getRecordRequest: postId(" + postId + "), memberId(" + memberId + ")");
         return ResponseEntity.status(HttpStatus.OK).body(
             ResponseDTO.res(HttpStatus.OK, "좋아요/싫어요를 성공적으로 조회했습니다.",
                 recordService.getRecord(memberId, postId)));
     }
 
     @DeleteMapping
-    public ResponseEntity<ResponseDTO<Void>> deleteRecord(
-        @Valid @RequestBody DeleteRecordRequestDTO deleteRecordRequestDTO) {
-        log.info("DeleteRecordRequest: " + deleteRecordRequestDTO);
-        recordService.deleteRecord(deleteRecordRequestDTO);
+    public ResponseEntity<ResponseDTO<Object>> deleteRecord(
+        @Valid @RequestBody DeleteRecordRequestDTO deleteRecordRequestDTO, HttpSession session) {
+        Long memberId = (Long) session.getAttribute("MEMBER");
+        log.info(
+            "DeleteRecordRequest: postId(" + deleteRecordRequestDTO.getPostId() + "), memberId("
+                + memberId + ")");
+        recordService.deleteRecord(deleteRecordRequestDTO, memberId);
         return ResponseEntity.status(HttpStatus.OK)
-            .body(ResponseDTO.res(HttpStatus.OK, "좋아요/싫어요를 성공적으로 취소했습니다.", null));
+            .body(ResponseDTO.res(HttpStatus.OK, "좋아요/싫어요를 성공적으로 취소했습니다."));
     }
 }

--- a/src/main/java/com/fasttime/domain/record/controller/RecordRestControllerAdvice.java
+++ b/src/main/java/com/fasttime/domain/record/controller/RecordRestControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.fasttime.domain.record.controller;
 
+import com.fasttime.domain.record.exception.AlreadyExistsRecordException;
 import com.fasttime.domain.record.exception.DuplicateRecordException;
 import com.fasttime.global.util.ResponseDTO;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +16,14 @@ class RecordRestControllerAdvice {
     @ExceptionHandler
     ResponseEntity<ResponseDTO<Object>> duplicateRecordException(DuplicateRecordException e) {
         log.error("DuplicateRecordException: " + e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ResponseDTO.res(HttpStatus.BAD_REQUEST, e.getMessage()));
+    }
+
+    @ExceptionHandler
+    ResponseEntity<ResponseDTO<Object>> alreadyExistsRecordException(
+        AlreadyExistsRecordException e) {
+        log.error("AlreadyExistsRecordException: " + e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(ResponseDTO.res(HttpStatus.BAD_REQUEST, e.getMessage()));
     }

--- a/src/main/java/com/fasttime/domain/record/dto/request/CreateRecordRequestDTO.java
+++ b/src/main/java/com/fasttime/domain/record/dto/request/CreateRecordRequestDTO.java
@@ -15,6 +15,6 @@ public class CreateRecordRequestDTO {
     @NotNull(message = "게시글 ID를 입력하세요.")
     private Long postId;
 
-    @NotNull(message = "회원 ID를 입력하세요.")
-    private Long memberId;
+    @NotNull(message = "좋아요 = true, 싫어요 = false 를 입력하세요.")
+    private Boolean isLike;
 }

--- a/src/main/java/com/fasttime/domain/record/dto/request/DeleteRecordRequestDTO.java
+++ b/src/main/java/com/fasttime/domain/record/dto/request/DeleteRecordRequestDTO.java
@@ -14,7 +14,4 @@ public class DeleteRecordRequestDTO {
 
     @NotNull(message = "게시글 ID를 입력하세요.")
     private Long postId;
-
-    @NotNull(message = "회원 ID를 입력하세요.")
-    private Long memberId;
 }

--- a/src/main/java/com/fasttime/domain/record/exception/AlreadyExistsRecordException.java
+++ b/src/main/java/com/fasttime/domain/record/exception/AlreadyExistsRecordException.java
@@ -1,0 +1,11 @@
+package com.fasttime.domain.record.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import org.springframework.http.HttpStatus;
+
+public class AlreadyExistsRecordException extends ApplicationException {
+
+    public AlreadyExistsRecordException() {
+        super(HttpStatus.BAD_REQUEST, "한 게시글에 좋아요와 싫어요를 모두 등록할 수는 없습니다.");
+    }
+}

--- a/src/main/java/com/fasttime/domain/record/exception/DuplicateRecordException.java
+++ b/src/main/java/com/fasttime/domain/record/exception/DuplicateRecordException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class DuplicateRecordException extends ApplicationException {
 
-    public DuplicateRecordException(String message) {
-        super(HttpStatus.BAD_REQUEST, message);
+    public DuplicateRecordException() {
+        super(HttpStatus.BAD_REQUEST, "중복된 좋아요/싫어요 등록 요청입니다.");
     }
 }

--- a/src/main/java/com/fasttime/domain/record/repository/RecordRepository.java
+++ b/src/main/java/com/fasttime/domain/record/repository/RecordRepository.java
@@ -8,5 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RecordRepository extends JpaRepository<Record, Long> {
 
     Optional<Record> findByMemberIdAndPostId(Long memberId, Long postId);
+
     Optional<List<Record>> findAllByPostId(long postId);
 }

--- a/src/main/java/com/fasttime/domain/record/service/RecordService.java
+++ b/src/main/java/com/fasttime/domain/record/service/RecordService.java
@@ -9,6 +9,7 @@ import com.fasttime.domain.record.dto.RecordDTO;
 import com.fasttime.domain.record.dto.request.CreateRecordRequestDTO;
 import com.fasttime.domain.record.dto.request.DeleteRecordRequestDTO;
 import com.fasttime.domain.record.entity.Record;
+import com.fasttime.domain.record.exception.AlreadyExistsRecordException;
 import com.fasttime.domain.record.exception.DuplicateRecordException;
 import com.fasttime.domain.record.exception.RecordNotFoundException;
 import com.fasttime.domain.record.repository.RecordRepository;
@@ -31,13 +32,15 @@ public class RecordService {
     private final PostQueryService postQueryService;
     private final MemberService memberService;
 
-    public void createRecord(CreateRecordRequestDTO req, boolean isLike) {
-        PostDetailResponseDto postResponse = postQueryService.findById(req.getPostId());
-        Member member = memberService.getMember(req.getMemberId());
-        checkDuplicateRecord(member.getId(), postResponse.getId(), isLike);
+    public void createRecord(CreateRecordRequestDTO createRecordRequestDTO, Long memberId) {
+        PostDetailResponseDto postResponse = postQueryService.findById(
+            createRecordRequestDTO.getPostId());
+        Member member = memberService.getMember(memberId);
+        checkDuplicateRecords(member.getId(), postResponse.getId(),
+            createRecordRequestDTO.getIsLike());
         recordRepository.save(
             Record.builder().member(member).post(Post.builder().id(postResponse.getId()).build())
-                .isLike(isLike).build());
+                .isLike(createRecordRequestDTO.getIsLike()).build());
     }
 
     public RecordDTO getRecord(long memberId, long postId) {
@@ -46,19 +49,19 @@ public class RecordService {
             .orElse(RecordDTO.builder().id(null).memberId(null).postId(null).isLike(null).build());
     }
 
-    public void deleteRecord(DeleteRecordRequestDTO req) {
-        Record record = recordRepository.findByMemberIdAndPostId(req.getMemberId(), req.getPostId())
+    public void deleteRecord(DeleteRecordRequestDTO req, Long memberId) {
+        Record record = recordRepository.findByMemberIdAndPostId(memberId, req.getPostId())
             .orElseThrow(RecordNotFoundException::new);
         recordRepository.delete(record);
     }
 
-    private void checkDuplicateRecord(long memberId, long postId, boolean isLike) {
+    private void checkDuplicateRecords(long memberId, long postId, boolean isLike) {
         Optional<Record> record = recordRepository.findByMemberIdAndPostId(memberId, postId);
         if (record.isPresent()) {
             if (record.get().isLike() == isLike) {
-                throw new DuplicateRecordException("중복된 요청입니다.");
+                throw new DuplicateRecordException();
             } else {
-                throw new DuplicateRecordException("한 게시글에 대해 좋아요와 싫어요를 모두 할 수는 없습니다.");
+                throw new AlreadyExistsRecordException();
             }
         }
     }

--- a/src/test/java/com/fasttime/domain/record/docs/RecordControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/record/docs/RecordControllerDocsTest.java
@@ -1,7 +1,6 @@
 package com.fasttime.domain.record.docs;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -47,69 +46,45 @@ public class RecordControllerDocsTest extends RestDocsSupport {
     ConstraintDescriptions deleteRecordRequestConstraints = new ConstraintDescriptions(
         DeleteRecordRequestDTO.class);
 
-    @DisplayName("좋아요 등록 API 문서화")
+    @DisplayName("좋아요/싫어요 등록 API 문서화")
     @Test
     void createLike() throws Exception {
         // given
-        CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L).postId(1L)
+        CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().postId(1L).isLike(true)
             .build();
         doNothing().when(recordService)
-            .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
+            .createRecord(any(CreateRecordRequestDTO.class), any(Long.class));
         String json = new ObjectMapper().writeValueAsString(request);
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("MEMBER", 1L);
 
         // when, then
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/record/like").content(json)
-            .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isCreated()).andDo(
-            document("record-like-create", preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()), requestFields(
-                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자")
-                        .attributes(key("constraints").value(
-                            createRecordRequestConstraints.descriptionsForProperty("memberId"))),
-                    fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자")
-                        .attributes(key("constraints").value(
-                            createRecordRequestConstraints.descriptionsForProperty("postId")))),
-                responseFields(
-                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
-                    fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
-                    fieldWithPath("data").type(JsonFieldType.NULL).description("응답데이터"))));
-    }
-
-    @DisplayName("싫어요 등록 API 문서화")
-    @Test
-    void createHate() throws Exception {
-        // given
-        CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L).postId(1L)
-            .build();
-        doNothing().when(recordService)
-            .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
-        String json = new ObjectMapper().writeValueAsString(request);
-
-        // when, then
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/record/hate").content(json)
-            .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isCreated()).andDo(
-            document("record-hate-create", preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()), requestFields(
-                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자")
-                        .attributes(key("constraints").value(
-                            createRecordRequestConstraints.descriptionsForProperty("memberId"))),
-                    fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자")
-                        .attributes(key("constraints").value(
-                            createRecordRequestConstraints.descriptionsForProperty("postId")))),
-                responseFields(
-                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
-                    fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
-                    fieldWithPath("data").type(JsonFieldType.NULL).description("응답데이터"))));
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/record").content(json)
+                .contentType(MediaType.APPLICATION_JSON).session(session))
+            .andExpect(status().isCreated()).andDo(
+                document("record-create", preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()), requestFields(
+                        fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자")
+                            .attributes(key("constraints").value(
+                                createRecordRequestConstraints.descriptionsForProperty("postId"))),
+                        fieldWithPath("isLike").type(JsonFieldType.BOOLEAN)
+                            .description("좋아요(true)/싫어요(false)").attributes(key("constraints").value(
+                                createRecordRequestConstraints.descriptionsForProperty("isLike")))),
+                    responseFields(
+                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+                        fieldWithPath("data").type(JsonFieldType.NULL).description("응답데이터"))));
     }
 
     @DisplayName("좋아요/싫어요 조회 API 문서화")
     @Test
     void getRecord() throws Exception {
         // given
-        MockHttpSession session = new MockHttpSession();
-        session.setAttribute("MEMBER", 1L);
         RecordDTO recordDTO = RecordDTO.builder().id(1L).memberId(1L).postId(1L).isLike(true)
             .build();
         given(recordService.getRecord(any(Long.class), any(Long.class))).willReturn(recordDTO);
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("MEMBER", 1L);
 
         // when, then
         mockMvc.perform(
@@ -127,17 +102,17 @@ public class RecordControllerDocsTest extends RestDocsSupport {
                             .description("회원 식별자"),
                         fieldWithPath("data.postId").type(JsonFieldType.NUMBER).optional()
                             .description("게시글 식별자"),
-                        fieldWithPath("data.isLike").type(JsonFieldType.BOOLEAN)
-                            .description("좋아요(1), 싫어요(0)"))));
+                        fieldWithPath("data.isLike").type(JsonFieldType.BOOLEAN).optional()
+                            .description("좋아요(true)/싫어요(false)"))));
     }
 
     @DisplayName("좋아요/싫어요 취소 API 문서화")
     @Test
     void deleteRecord() throws Exception {
         // given
-        DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().memberId(1L).postId(1L)
-            .build();
-        doNothing().when(recordService).deleteRecord(any(DeleteRecordRequestDTO.class));
+        DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().postId(1L).build();
+        doNothing().when(recordService)
+            .deleteRecord(any(DeleteRecordRequestDTO.class), any(Long.class));
         String json = new ObjectMapper().writeValueAsString(request);
 
         // when, then
@@ -145,9 +120,6 @@ public class RecordControllerDocsTest extends RestDocsSupport {
             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk()).andDo(
             document("record-delete", preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()), requestFields(
-                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자")
-                        .attributes(key("constraints").value(
-                            deleteRecordRequestConstraints.descriptionsForProperty("memberId"))),
                     fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자")
                         .attributes(key("constraints").value(
                             deleteRecordRequestConstraints.descriptionsForProperty("postId")))),

--- a/src/test/java/com/fasttime/domain/record/unit/controller/RecordRestControllerTest.java
+++ b/src/test/java/com/fasttime/domain/record/unit/controller/RecordRestControllerTest.java
@@ -1,7 +1,6 @@
 package com.fasttime.domain.record.unit.controller;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -37,88 +36,47 @@ public class RecordRestControllerTest {
     RecordService recordService;
 
     @Nested
-    @DisplayName("createLike()는")
-    class Context_createLike {
+    @DisplayName("createRecord()는")
+    class Context_createRecord {
 
         @Test
         @DisplayName("게시글을 좋아요 할 수 있다.")
-        void _willSuccess() throws Exception {
+        void like_willSuccess() throws Exception {
             // given
-            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L)
-                .postId(1L).build();
+            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().postId(1L)
+                .isLike(true).build();
             doNothing().when(recordService)
-                .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
+                .createRecord(any(CreateRecordRequestDTO.class), any(Long.class));
             String json = new ObjectMapper().writeValueAsString(request);
+            MockHttpSession session = new MockHttpSession();
+            session.setAttribute("MEMBER", 1L);
 
             // when, then
             mockMvc.perform(
-                    post("/api/v1/record/like").content(json).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated()).andExpect(jsonPath("$.message").exists())
-                .andDo(print());
+                    post("/api/v1/record").content(json).contentType(MediaType.APPLICATION_JSON)
+                        .session(session)).andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.data").isEmpty()).andDo(print());
         }
-
-        @Nested
-        @DisplayName("postId가 ")
-        class Element_postId {
-
-            @Test
-            @DisplayName("null일 경우 좋아요 할 수 없다.")
-            void null_willFail() throws Exception {
-                // given
-                CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L)
-                    .postId(null).build();
-                doNothing().when(recordService)
-                    .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
-                String json = new ObjectMapper().writeValueAsString(request);
-
-                // when, then
-                mockMvc.perform(post("/api/v1/record/like").content(json)
-                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").exists()).andDo(print());
-            }
-        }
-
-        @Nested
-        @DisplayName("memberId가 ")
-        class Element_memberId {
-
-            @Test
-            @DisplayName("null일 경우 좋아요 할 수 없다.")
-            void null_willFail() throws Exception {
-                // given
-                CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(null)
-                    .postId(1L).build();
-                doNothing().when(recordService)
-                    .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
-                String json = new ObjectMapper().writeValueAsString(request);
-
-                // when, then
-                mockMvc.perform(post("/api/v1/record/like").content(json)
-                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").exists()).andDo(print());
-            }
-        }
-    }
-
-    @Nested
-    @DisplayName("createHate()는")
-    class Context_createHate {
 
         @Test
         @DisplayName("게시글을 싫어요 할 수 있다.")
-        void _willSuccess() throws Exception {
+        void hate_willSuccess() throws Exception {
             // given
-            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L)
-                .postId(1L).build();
+            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().postId(1L)
+                .isLike(false).build();
             doNothing().when(recordService)
-                .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
+                .createRecord(any(CreateRecordRequestDTO.class), any(Long.class));
             String json = new ObjectMapper().writeValueAsString(request);
+            MockHttpSession session = new MockHttpSession();
+            session.setAttribute("MEMBER", 1L);
 
             // when, then
             mockMvc.perform(
-                    post("/api/v1/record/hate").content(json).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated()).andExpect(jsonPath("$.message").exists())
-                .andDo(print());
+                    post("/api/v1/record").content(json).contentType(MediaType.APPLICATION_JSON)
+                        .session(session)).andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.data").isEmpty()).andDo(print());
         }
 
         @Nested
@@ -126,40 +84,50 @@ public class RecordRestControllerTest {
         class Element_postId {
 
             @Test
-            @DisplayName("null일 경우 싫어요 할 수 없다.")
+            @DisplayName("null일 경우 좋아요/싫어요를 등록할 수 없다.")
             void null_willFail() throws Exception {
                 // given
-                CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L)
-                    .postId(null).build();
+                CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().postId(null)
+                    .isLike(true).build();
                 doNothing().when(recordService)
-                    .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
+                    .createRecord(any(CreateRecordRequestDTO.class), any(Long.class));
                 String json = new ObjectMapper().writeValueAsString(request);
+                MockHttpSession session = new MockHttpSession();
+                session.setAttribute("MEMBER", 1L);
 
                 // when, then
-                mockMvc.perform(post("/api/v1/record/hate").content(json)
-                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+                mockMvc.perform(
+                        post("/api/v1/record").content(json).contentType(MediaType.APPLICATION_JSON)
+                            .session(session)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").exists())
+                    .andExpect(jsonPath("$.message").exists())
+                    .andExpect(jsonPath("$.data").isEmpty()).andDo(print());
             }
         }
 
         @Nested
-        @DisplayName("memberId가 ")
-        class Element_memberId {
+        @DisplayName("isLike가 ")
+        class Element_isLike {
 
             @Test
-            @DisplayName("null일 경우 싫어요 할 수 없다.")
+            @DisplayName("null일 경우 좋아요/싫어요를 등록할 수 없다.")
             void null_willFail() throws Exception {
                 // given
-                CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(null)
-                    .postId(1L).build();
+                CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().postId(1L)
+                    .isLike(null).build();
                 doNothing().when(recordService)
-                    .createRecord(any(CreateRecordRequestDTO.class), anyBoolean());
+                    .createRecord(any(CreateRecordRequestDTO.class), any(Long.class));
                 String json = new ObjectMapper().writeValueAsString(request);
+                MockHttpSession session = new MockHttpSession();
+                session.setAttribute("MEMBER", 1L);
 
                 // when, then
-                mockMvc.perform(post("/api/v1/record/hate").content(json)
-                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").exists()).andDo(print());
+                mockMvc.perform(
+                        post("/api/v1/record").content(json).contentType(MediaType.APPLICATION_JSON)
+                            .session(session)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").exists())
+                    .andExpect(jsonPath("$.message").exists())
+                    .andExpect(jsonPath("$.data").isEmpty()).andDo(print());
             }
         }
     }
@@ -172,17 +140,17 @@ public class RecordRestControllerTest {
         @DisplayName("좋아요/싫어요 데이터를 불러올 수 있다.")
         void _willSuccess() throws Exception {
             // given
-            MockHttpSession session = new MockHttpSession();
-            session.setAttribute("MEMBER", 1L);
             RecordDTO recordDTO = RecordDTO.builder().id(1L).memberId(1L).postId(1L).isLike(true)
                 .build();
             given(recordService.getRecord(any(Long.class), any(Long.class))).willReturn(recordDTO);
+            MockHttpSession session = new MockHttpSession();
+            session.setAttribute("MEMBER", 1L);
 
             // when, then
             mockMvc.perform(get("/api/v1/record/{postId}", 1L).session(session)
                     .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
-                .andExpect(jsonPath("$.data.id").exists())
+                .andExpect(jsonPath("$.data").isMap()).andExpect(jsonPath("$.data.id").exists())
                 .andExpect(jsonPath("$.data.memberId").exists())
                 .andExpect(jsonPath("$.data.postId").exists())
                 .andExpect(jsonPath("$.data.isLike").exists()).andDo(print());
@@ -197,16 +165,19 @@ public class RecordRestControllerTest {
         @DisplayName("게시글 좋아요(싫어요)를 취소할 수 있다.")
         void _willSuccess() throws Exception {
             // given
-            DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().memberId(1L)
-                .postId(1L).build();
-            doNothing().when(recordService).deleteRecord(any(DeleteRecordRequestDTO.class));
+            DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().postId(1L).build();
+            doNothing().when(recordService)
+                .deleteRecord(any(DeleteRecordRequestDTO.class), any(Long.class));
             String json = new ObjectMapper().writeValueAsString(request);
+            MockHttpSession session = new MockHttpSession();
+            session.setAttribute("MEMBER", 1L);
 
             // when, then
             mockMvc.perform(
-                    delete("/api/v1/record").content(json).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk()).andExpect(jsonPath("$.message").exists())
-                .andDo(print());
+                    delete("/api/v1/record").content(json).contentType(MediaType.APPLICATION_JSON)
+                        .session(session)).andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.data").isEmpty()).andDo(print());
         }
 
         @Nested
@@ -217,37 +188,21 @@ public class RecordRestControllerTest {
             @DisplayName("null일 경우 취소할 수 없다.")
             void null_willFail() throws Exception {
                 // given
-                DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().memberId(1L)
-                    .postId(null).build();
-                doNothing().when(recordService).deleteRecord(any(DeleteRecordRequestDTO.class));
+                DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().postId(null)
+                    .build();
+                doNothing().when(recordService)
+                    .deleteRecord(any(DeleteRecordRequestDTO.class), any(Long.class));
                 String json = new ObjectMapper().writeValueAsString(request);
+                MockHttpSession session = new MockHttpSession();
+                session.setAttribute("MEMBER", 1L);
 
                 // when, then
                 mockMvc.perform(
-                        delete("/api/v1/record").content(json).contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message").exists())
-                    .andDo(print());
-            }
-        }
-
-        @Nested
-        @DisplayName("memberId가 ")
-        class Element_memberId {
-
-            @Test
-            @DisplayName("null일 경우 취소할 수 없다.")
-            void null_willFail() throws Exception {
-                // given
-                DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().memberId(null)
-                    .postId(1L).build();
-                doNothing().when(recordService).deleteRecord(any(DeleteRecordRequestDTO.class));
-                String json = new ObjectMapper().writeValueAsString(request);
-
-                // when, then
-                mockMvc.perform(
-                        delete("/api/v1/record").content(json).contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message").exists())
-                    .andDo(print());
+                        delete("/api/v1/record").content(json).contentType(MediaType.APPLICATION_JSON)
+                            .session(session)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").exists())
+                    .andExpect(jsonPath("$.message").exists())
+                    .andExpect(jsonPath("$.data").isEmpty()).andDo(print());
             }
         }
     }

--- a/src/test/java/com/fasttime/domain/record/unit/service/RecordServiceTest.java
+++ b/src/test/java/com/fasttime/domain/record/unit/service/RecordServiceTest.java
@@ -17,6 +17,7 @@ import com.fasttime.domain.record.dto.RecordDTO;
 import com.fasttime.domain.record.dto.request.CreateRecordRequestDTO;
 import com.fasttime.domain.record.dto.request.DeleteRecordRequestDTO;
 import com.fasttime.domain.record.entity.Record;
+import com.fasttime.domain.record.exception.AlreadyExistsRecordException;
 import com.fasttime.domain.record.exception.DuplicateRecordException;
 import com.fasttime.domain.record.exception.RecordNotFoundException;
 import com.fasttime.domain.record.repository.RecordRepository;
@@ -58,19 +59,18 @@ public class RecordServiceTest {
         @DisplayName("게시글을 좋아요 할 수 있다.")
         void like_willSuccess() {
             // given
-            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L)
-                .postId(1L).build();
+            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().postId(1L)
+                .isLike(true).build();
             PostDetailResponseDto post = PostDetailResponseDto.builder().id(1L).build();
             Member member = Member.builder().id(1L).build();
             Optional<Record> record = Optional.empty();
-
             given(postQueryService.findById(any(Long.class))).willReturn(post);
             given(memberService.getMember(any(Long.class))).willReturn(member);
             given(recordRepository.findByMemberIdAndPostId(any(long.class),
                 any(long.class))).willReturn(record);
 
             // when
-            recordService.createRecord(request, true);
+            recordService.createRecord(request, 1L);
 
             // then
             verify(recordRepository, times(1)).save(any(Record.class));
@@ -80,19 +80,18 @@ public class RecordServiceTest {
         @DisplayName("게시글을 싫어요 할 수 있다.")
         void hate_willSuccess() {
             // given
-            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L)
-                .postId(1L).build();
+            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder()
+                .postId(1L).isLike(false).build();
             PostDetailResponseDto post = PostDetailResponseDto.builder().id(1L).build();
             Member member = Member.builder().id(1L).build();
             Optional<Record> record = Optional.empty();
-
             given(postQueryService.findById(any(Long.class))).willReturn(post);
             given(memberService.getMember(any(Long.class))).willReturn(member);
             given(recordRepository.findByMemberIdAndPostId(any(long.class),
                 any(long.class))).willReturn(record);
 
             // when
-            recordService.createRecord(request, false);
+            recordService.createRecord(request, 1L);
 
             // then
             verify(recordRepository, times(1)).save(any(Record.class));
@@ -102,14 +101,13 @@ public class RecordServiceTest {
         @DisplayName("이미 좋아요(싫어요)를 한 게시글에 다시 좋아요(싫어요)를 등록할 수 없다.")
         void duplicateRecord1_willFail() {
             // given
-            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L)
-                .postId(1L).build();
+            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder()
+                .postId(1L).isLike(true).build();
             PostDetailResponseDto post = PostDetailResponseDto.builder().id(1L).build();
             Member member = Member.builder().id(1L).build();
             Optional<Record> record = Optional.of(
                 Record.builder().member(member).post(Post.builder().id(post.getId()).build())
                     .isLike(true).build());
-
             given(postQueryService.findById(any(Long.class))).willReturn(post);
             given(memberService.getMember(any(Long.class))).willReturn(member);
             given(recordRepository.findByMemberIdAndPostId(any(long.class),
@@ -117,33 +115,32 @@ public class RecordServiceTest {
 
             // when, then
             Throwable exception = assertThrows(DuplicateRecordException.class, () -> {
-                recordService.createRecord(request, true);
+                recordService.createRecord(request, 1L);
             });
-            assertEquals("중복된 요청입니다.", exception.getMessage());
+            assertEquals("중복된 좋아요/싫어요 등록 요청입니다.", exception.getMessage());
         }
 
         @Test
         @DisplayName("좋아요와 싫어요를 중복으로 등록할 수 없다.")
         void duplicateRecord2_willFail() {
             // given
-            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder().memberId(1L)
-                .postId(1L).build();
+            CreateRecordRequestDTO request = CreateRecordRequestDTO.builder()
+                .postId(1L).isLike(true).build();
             PostDetailResponseDto post = PostDetailResponseDto.builder().id(1L).build();
             Member member = Member.builder().id(1L).build();
             Optional<Record> record = Optional.of(
                 Record.builder().member(member).post(Post.builder().id(post.getId()).build())
                     .isLike(false).build());
-
             given(postQueryService.findById(any(Long.class))).willReturn(post);
             given(memberService.getMember(any(Long.class))).willReturn(member);
             given(recordRepository.findByMemberIdAndPostId(any(long.class),
                 any(long.class))).willReturn(record);
 
             // when, then
-            Throwable exception = assertThrows(DuplicateRecordException.class, () -> {
-                recordService.createRecord(request, true);
+            Throwable exception = assertThrows(AlreadyExistsRecordException.class, () -> {
+                recordService.createRecord(request, 1L);
             });
-            assertEquals("한 게시글에 대해 좋아요와 싫어요를 모두 할 수는 없습니다.", exception.getMessage());
+            assertEquals("한 게시글에 좋아요와 싫어요를 모두 등록할 수는 없습니다.", exception.getMessage());
         }
     }
 
@@ -152,14 +149,13 @@ public class RecordServiceTest {
     class Context_getRecord {
 
         @Test
-        @DisplayName("좋아요/싫어요 데이터를 가져올 수 있다.")
+        @DisplayName("회원이 해당 게시물에 대해 등록한 좋아요/싫어요 내역을 가져올 수 있다.")
         void _willSuccess() {
             // given
             Post post = Post.builder().id(1L).build();
             Member member = Member.builder().id(1L).build();
             Optional<Record> record = Optional.of(
                 Record.builder().id(1L).post(post).member(member).isLike(true).build());
-
             given(recordRepository.findByMemberIdAndPostId(any(Long.class),
                 any(Long.class))).willReturn(record);
 
@@ -169,17 +165,15 @@ public class RecordServiceTest {
             // then
             assertThat(result).extracting("id", "postId", "memberId", "isLike")
                 .containsExactly(1L, 1L, 1L, true);
-
             verify(recordRepository, times(1)).findByMemberIdAndPostId(any(Long.class),
                 any(Long.class));
         }
 
         @Test
-        @DisplayName("좋아요/싫어요 데이터가 없다면 id값이 null인 ResponseDTO를 반환한다.")
+        @DisplayName("회원이 해당 게시물에 대해 등록한 좋아요/싫어요 데이터가 없다면 id값이 null인 ResponseDTO를 반환한다.")
         void noRecord_willSuccess() {
             // given
             Optional<Record> record = Optional.empty();
-
             given(recordRepository.findByMemberIdAndPostId(any(Long.class),
                 any(Long.class))).willReturn(record);
 
@@ -189,7 +183,6 @@ public class RecordServiceTest {
             // then
             assertThat(result).extracting("id", "postId", "memberId", "isLike")
                 .containsExactly(null, null, null, null);
-
             verify(recordRepository, times(1)).findByMemberIdAndPostId(any(Long.class),
                 any(Long.class));
         }
@@ -203,18 +196,17 @@ public class RecordServiceTest {
         @DisplayName("게시글 좋아요/싫어요를 취소할 수 있다.")
         void _willSuccess() {
             // given
-            DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().memberId(1L)
+            DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder()
                 .postId(1L).build();
             Post post = Post.builder().id(1L).build();
             Member member = Member.builder().id(1L).build();
             Optional<Record> record = Optional.of(
                 Record.builder().id(1L).member(member).post(post).isLike(true).build());
-
             given(recordRepository.findByMemberIdAndPostId(any(long.class),
                 any(long.class))).willReturn(record);
 
             // when
-            recordService.deleteRecord(request);
+            recordService.deleteRecord(request, 1L);
 
             // then
             verify(recordRepository, times(1)).delete(any(Record.class));
@@ -224,16 +216,15 @@ public class RecordServiceTest {
         @DisplayName("게시글 좋아요/싫어요 한 적이 없다면 좋아요/싫어요를 취소할 수 없다.")
         void recordNotFound_willSuccess() {
             // given
-            DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder().memberId(1L)
+            DeleteRecordRequestDTO request = DeleteRecordRequestDTO.builder()
                 .postId(1L).build();
             Optional<Record> record = Optional.empty();
-
             given(recordRepository.findByMemberIdAndPostId(any(long.class),
                 any(long.class))).willReturn(record);
 
             // when, then
             Throwable exception = assertThrows(RecordNotFoundException.class, () -> {
-                recordService.deleteRecord(request);
+                recordService.deleteRecord(request, 1L);
             });
             assertEquals("존재하지 않는 좋아요/싫어요 입니다.", exception.getMessage());
         }
@@ -244,7 +235,7 @@ public class RecordServiceTest {
     class Context_getRecordCount {
 
         @Test
-        @DisplayName("좋아요/싫어요 합계를 가져올 수 있다.")
+        @DisplayName("게시물에 등록된 좋아요/싫어요 합계를 가져올 수 있다.")
         void _willSuccess() {
             // given
             Post post = Post.builder().id(1L).build();
@@ -254,16 +245,13 @@ public class RecordServiceTest {
             list.add(Record.builder().id(2L).post(post).member(member).isLike(true).build());
             list.add(Record.builder().id(3L).post(post).member(member).isLike(false).build());
             Optional<List<Record>> records = Optional.of(list);
-
             given(recordRepository.findAllByPostId(any(Long.class))).willReturn(records);
 
             // when
             Map<String, Integer> result = recordService.getRecordCount(1L);
 
             // then
-            assertThat(result).extracting("likeCount", "hateCount")
-                .containsExactly(2, 1);
-
+            assertThat(result).extracting("likeCount", "hateCount").containsExactly(2, 1);
             verify(recordRepository, times(1)).findAllByPostId(any(Long.class));
         }
     }


### PR DESCRIPTION
### 개발 내용
- 세션 사용으로 인한 좋아요/싫어요 API 수정
  - 좋아요/싫어요 등록, 조회, 삭제 시 memberId를 필드가 아닌 세션에서 가져옴
  - 좋아요/싫어요 등록 API url 수정
  - 좋아요/싫어요 등록 요청 필드로 isLike 추가
- 좋아요/싫어요 익셉션 추가
- 좋아요/싫어요 Service, Controller, Repository  리팩토링
- 좋아요/싫어요 테스트 코드 수정
- 좋아요/싫어요 REST Docs 수정