### PR TITLE
[refactor] 댓글 기능 리팩토링

### DIFF
--- a/src/docs/asciidoc/comment/comment-api.adoc
+++ b/src/docs/asciidoc/comment/comment-api.adoc
@@ -28,7 +28,6 @@ include::{snippets}/comment-create/response-fields.adoc[]
 === HttpRequest
 
 include::{snippets}/comments-search-mypage/http-request.adoc[]
-include::{snippets}/comments-search-mypage/path-parameters.adoc[]
 
 === HttpResponse
 

--- a/src/main/java/com/fasttime/domain/comment/controller/CommentRestController.java
+++ b/src/main/java/com/fasttime/domain/comment/controller/CommentRestController.java
@@ -1,13 +1,14 @@
 package com.fasttime.domain.comment.controller;
 
-import com.fasttime.domain.comment.dto.request.CreateCommentRequest;
-import com.fasttime.domain.comment.dto.request.DeleteCommentRequest;
-import com.fasttime.domain.comment.dto.request.UpdateCommentRequest;
+import com.fasttime.domain.comment.dto.request.CreateCommentRequestDTO;
+import com.fasttime.domain.comment.dto.request.DeleteCommentRequestDTO;
+import com.fasttime.domain.comment.dto.request.UpdateCommentRequestDTO;
 import com.fasttime.domain.comment.dto.response.MyPageCommentResponseDTO;
 import com.fasttime.domain.comment.dto.response.PostCommentResponseDTO;
 import com.fasttime.domain.comment.service.CommentService;
 import com.fasttime.global.util.ResponseDTO;
 import java.util.List;
+import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,21 +32,22 @@ public class CommentRestController {
     private final CommentService commentService;
 
     @PostMapping
-    public ResponseEntity<ResponseDTO<PostCommentResponseDTO>> createComment(
-        @Valid @RequestBody CreateCommentRequest createCommentRequest) {
-        log.info("CreateCommentRequest: " + createCommentRequest);
-        return ResponseEntity.status(HttpStatus.CREATED).body(
-            ResponseDTO.res(HttpStatus.CREATED, "댓글을 성공적으로 등록했습니다.",
-                commentService.createComment(createCommentRequest)));
+    public ResponseEntity<ResponseDTO<Object>> createComment(
+        @Valid @RequestBody CreateCommentRequestDTO createCommentRequestDTO, HttpSession session) {
+        log.info("CreateCommentRequest: " + createCommentRequestDTO);
+        commentService.createComment(createCommentRequestDTO,
+            (Long) session.getAttribute("MEMBER"));
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ResponseDTO.res(HttpStatus.CREATED, "댓글을 성공적으로 등록했습니다."));
     }
 
-    @GetMapping("/my-page/{memberId}")
+    @GetMapping("/my-page")
     public ResponseEntity<ResponseDTO<List<MyPageCommentResponseDTO>>> getCommentsByMemberId(
-        @PathVariable long memberId) {
-        log.info("getCommentsByMemberId: " + memberId);
+        HttpSession session) {
+        log.info("getCommentsByMemberId: " + session.getAttribute("MEMBER"));
         return ResponseEntity.status(HttpStatus.OK).body(
             ResponseDTO.res(HttpStatus.OK, "댓글을 성공적으로 조회했습니다.",
-                commentService.getCommentsByMemberId(memberId)));
+                commentService.getCommentsByMemberId((Long) session.getAttribute("MEMBER"))));
     }
 
     @GetMapping("/{postId}")
@@ -58,20 +60,20 @@ public class CommentRestController {
     }
 
     @PatchMapping
-    public ResponseEntity<ResponseDTO<PostCommentResponseDTO>> updateComment(
-        @Valid @RequestBody UpdateCommentRequest updateCommentRequest) {
-        log.info("UpdateCommentRequest: " + updateCommentRequest);
-        return ResponseEntity.status(HttpStatus.OK).body(
-            ResponseDTO.res(HttpStatus.OK, "댓글 내용을 성공적으로 수정했습니다.",
-                commentService.updateComment(updateCommentRequest)));
+    public ResponseEntity<ResponseDTO<Object>> updateComment(
+        @Valid @RequestBody UpdateCommentRequestDTO updateCommentRequestDTO) {
+        log.info("UpdateCommentRequest: " + updateCommentRequestDTO);
+        commentService.updateComment(updateCommentRequestDTO);
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ResponseDTO.res(HttpStatus.OK, "댓글 내용을 성공적으로 수정했습니다."));
     }
 
     @DeleteMapping
-    public ResponseEntity<ResponseDTO<Void>> deleteComment(
-        @Valid @RequestBody DeleteCommentRequest deleteCommentRequest) {
-        log.info("DeleteCommentRequest: " + deleteCommentRequest);
-        commentService.deleteComment(deleteCommentRequest);
+    public ResponseEntity<ResponseDTO<Object>> deleteComment(
+        @Valid @RequestBody DeleteCommentRequestDTO deleteCommentRequestDTO) {
+        log.info("DeleteCommentRequest: " + deleteCommentRequestDTO);
+        commentService.deleteComment(deleteCommentRequestDTO);
         return ResponseEntity.status(HttpStatus.OK)
-            .body(ResponseDTO.res(HttpStatus.OK, "댓글을 성공적으로 삭제했습니다.", null));
+            .body(ResponseDTO.res(HttpStatus.OK, "댓글을 성공적으로 삭제했습니다."));
     }
 }

--- a/src/main/java/com/fasttime/domain/comment/dto/request/CreateCommentRequestDTO.java
+++ b/src/main/java/com/fasttime/domain/comment/dto/request/CreateCommentRequestDTO.java
@@ -12,13 +12,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class CreateCommentRequest {
+public class CreateCommentRequestDTO {
 
     @NotNull(message = "게시글 ID를 입력하세요.")
     private Long postId;
-
-    @NotNull(message = "회원 ID를 입력하세요.")
-    private Long memberId;
 
     @NotBlank(message = "댓글 내용을 입력하세요.")
     @Size(min = 1, max = 100, message = "내용을 100자 이내로 입력하세요.")

--- a/src/main/java/com/fasttime/domain/comment/dto/request/DeleteCommentRequestDTO.java
+++ b/src/main/java/com/fasttime/domain/comment/dto/request/DeleteCommentRequestDTO.java
@@ -10,8 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class DeleteCommentRequest {
+public class DeleteCommentRequestDTO {
 
-    @NotNull(message = "삭제할 댓글 ID를 입력하세요.")
-    Long id;
+    @NotNull(message = "삭제할 댓글 ID를 입력하세요.") Long id;
 }

--- a/src/main/java/com/fasttime/domain/comment/dto/request/UpdateCommentRequestDTO.java
+++ b/src/main/java/com/fasttime/domain/comment/dto/request/UpdateCommentRequestDTO.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class UpdateCommentRequest {
+public class UpdateCommentRequestDTO {
 
     @NotNull(message = "수정할 댓글 ID를 입력하세요.") Long id;
 

--- a/src/main/java/com/fasttime/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fasttime/domain/comment/service/CommentService.java
@@ -1,8 +1,8 @@
 package com.fasttime.domain.comment.service;
 
-import com.fasttime.domain.comment.dto.request.CreateCommentRequest;
-import com.fasttime.domain.comment.dto.request.DeleteCommentRequest;
-import com.fasttime.domain.comment.dto.request.UpdateCommentRequest;
+import com.fasttime.domain.comment.dto.request.CreateCommentRequestDTO;
+import com.fasttime.domain.comment.dto.request.DeleteCommentRequestDTO;
+import com.fasttime.domain.comment.dto.request.UpdateCommentRequestDTO;
 import com.fasttime.domain.comment.dto.response.MyPageCommentResponseDTO;
 import com.fasttime.domain.comment.dto.response.PostCommentResponseDTO;
 import com.fasttime.domain.comment.entity.Comment;
@@ -29,90 +29,39 @@ public class CommentService {
     private final PostQueryService postQueryService;
     private final MemberService memberService;
 
-    /**
-     * 댓글을 등록하는 메서드
-     *
-     * @param req 등록할 댓글 정보가 담긴 객체
-     * @return 등록한 댓글 DTO
-     */
-    public PostCommentResponseDTO createComment(CreateCommentRequest req) {
-        Comment parentComment = null;
-        // 대댓글인 경우
-        if (req.getParentCommentId() != null) {
-            parentComment = getComment(req.getParentCommentId());
-        }
-
-        PostDetailResponseDto postResponse = postQueryService.findById(req.getPostId());
-
-        return commentRepository.save(
-                Comment.builder().post(Post.builder().id(postResponse.getId()).build())
-                    .member(memberService.getMember(req.getMemberId())).content(req.getContent())
-                    .anonymity(req.getAnonymity()).parentComment(parentComment).build())
+    public void createComment(CreateCommentRequestDTO createCommentRequestDTO, Long memberId) {
+        Comment parentComment = isCommentOfComment(createCommentRequestDTO) ? getComment(
+            createCommentRequestDTO.getParentCommentId()) : null;
+        commentRepository.save(Comment.builder().post(Post.builder()
+                    .id(postQueryService.findById(createCommentRequestDTO.getPostId()).getId()).build())
+                .member(memberService.getMember(memberId)).content(createCommentRequestDTO.getContent())
+                .anonymity(createCommentRequestDTO.getAnonymity()).parentComment(parentComment).build())
             .toPostCommentResponseDTO();
     }
 
-    /**
-     * 회원 ID로 회원이 등록한 댓글 리스트를 조회하는 메서드
-     *
-     * @param memberId 댓글 리스트 조회의 기준이 될 회원 ID
-     * @return 회원이 등록한 댓글 DTO 리스트
-     */
-    public List<MyPageCommentResponseDTO> getCommentsByMemberId(long memberId) {
+    public List<MyPageCommentResponseDTO> getCommentsByMemberId(Long memberId) {
         return getCommentsByMember(memberService.getMember(memberId));
     }
 
-    /**
-     * 게시글 ID로 해당 게시글에 등록된 댓글 리스트를 조회하는 메서드
-     *
-     * @param postId 댓글 리스트 조회의 기준이 될 게시글 ID
-     * @return 게시글에 등록된 댓글 DTO 리스트
-     */
     public List<PostCommentResponseDTO> getCommentsByPostId(long postId) {
         PostDetailResponseDto postResponse = postQueryService.findById(postId);
         return getCommentsByPost(Post.builder().id(postResponse.getId()).build());
     }
 
-    /**
-     * 댓글을 수정하는 메서드
-     *
-     * @param req 수정할 댓글 정보와 수정 내용이 담긴 객체
-     * @return 수정한 댓글 DTO
-     */
-    public PostCommentResponseDTO updateComment(UpdateCommentRequest req) {
-        Comment comment = commentRepository.findById(req.getId())
-            .orElseThrow(CommentNotFoundException::new);
-        comment.updateContent(req.getContent());
-        return comment.toPostCommentResponseDTO();
+    public void updateComment(UpdateCommentRequestDTO updateCommentRequestDTO) {
+        Comment comment = getComment(updateCommentRequestDTO.getId());
+        comment.updateContent(updateCommentRequestDTO.getContent());
     }
 
-    /**
-     * 댓글을 삭제하는 메서드
-     *
-     * @param req 삭제할 댓글 ID가 담긴 객체
-     * @return 삭제한 댓글 DTO
-     */
-    public void deleteComment(DeleteCommentRequest req) {
-        Comment comment = commentRepository.findById(req.getId())
-            .orElseThrow(CommentNotFoundException::new);
+    public void deleteComment(DeleteCommentRequestDTO deleteCommentRequestDTO) {
+        Comment comment = getComment(deleteCommentRequestDTO.getId());
         comment.delete(LocalDateTime.now());
     }
 
-    /**
-     * 댓글 ID로 댓글 정보를 조회하는 메서드
-     *
-     * @param id 조회할 댓글의 ID
-     * @return 댓글 ID로 조회한 댓글 Entity
-     */
     public Comment getComment(Long id) {
         return commentRepository.findById(id).orElseThrow(CommentNotFoundException::new);
     }
 
-    /**
-     * 게시글에 등록된 댓글 리스트를 조회하는 메서드
-     *
-     * @param post 댓글 리스트를 조회할 게시글 Entity
-     * @return 게시글에 등록된 댓글 리스트
-     */
     public List<PostCommentResponseDTO> getCommentsByPost(Post post) {
         List<PostCommentResponseDTO> comments = new ArrayList<>();
         List<Comment> list = commentRepository.findAllByPost(post).orElseGet(ArrayList::new);
@@ -122,12 +71,6 @@ public class CommentService {
         return comments;
     }
 
-    /**
-     * 회원이 등록한 댓글 리스트를 조회하는 메서드
-     *
-     * @param member 댓글 리스트 조회의 기준이 될 회원 Entity
-     * @return 회원이 등록한 댓글 리스트
-     */
     public List<MyPageCommentResponseDTO> getCommentsByMember(Member member) {
         List<MyPageCommentResponseDTO> comments = new ArrayList<>();
         List<Comment> list = commentRepository.findAllByMember(member).orElseGet(ArrayList::new);
@@ -135,5 +78,9 @@ public class CommentService {
             comments.add(comment.toMyPageCommentResponseDTO());
         }
         return comments;
+    }
+
+    private boolean isCommentOfComment(CreateCommentRequestDTO createCommentRequestDTO) {
+        return createCommentRequestDTO.getParentCommentId() != null;
     }
 }

--- a/src/test/java/com/fasttime/domain/comment/docs/CommentControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/comment/docs/CommentControllerDocsTest.java
@@ -1,7 +1,6 @@
 package com.fasttime.domain.comment.docs;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -22,9 +21,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasttime.docs.RestDocsSupport;
 import com.fasttime.domain.comment.controller.CommentRestController;
-import com.fasttime.domain.comment.dto.request.CreateCommentRequest;
-import com.fasttime.domain.comment.dto.request.DeleteCommentRequest;
-import com.fasttime.domain.comment.dto.request.UpdateCommentRequest;
+import com.fasttime.domain.comment.dto.request.CreateCommentRequestDTO;
+import com.fasttime.domain.comment.dto.request.DeleteCommentRequestDTO;
+import com.fasttime.domain.comment.dto.request.UpdateCommentRequestDTO;
 import com.fasttime.domain.comment.dto.response.MyPageCommentResponseDTO;
 import com.fasttime.domain.comment.dto.response.PostCommentResponseDTO;
 import com.fasttime.domain.comment.service.CommentService;
@@ -32,6 +31,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.restdocs.constraints.ConstraintDescriptions;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -46,62 +46,44 @@ public class CommentControllerDocsTest extends RestDocsSupport {
     }
 
     ConstraintDescriptions createCommentRequestConstraints = new ConstraintDescriptions(
-        CreateCommentRequest.class);
+        CreateCommentRequestDTO.class);
     ConstraintDescriptions updateCommentRequestConstraints = new ConstraintDescriptions(
-        UpdateCommentRequest.class);
+        UpdateCommentRequestDTO.class);
     ConstraintDescriptions deleteCommentRequestConstraints = new ConstraintDescriptions(
-        DeleteCommentRequest.class);
+        DeleteCommentRequestDTO.class);
 
     @DisplayName("댓글 등록 API 문서화")
     @Test
     void createComment() throws Exception {
         // given
-        CreateCommentRequest request = CreateCommentRequest.builder().postId(1L).memberId(1L)
+        CreateCommentRequestDTO request = CreateCommentRequestDTO.builder().postId(1L)
             .content("test").anonymity(false).parentCommentId(null).build();
-        PostCommentResponseDTO postCommentResponseDto = PostCommentResponseDTO.builder().id(1L)
-            .memberId(1L).nickname("nickname").content("test").anonymity(false)
-            .parentCommentId(null).createdAt("2023-01-01 12:30:00").updatedAt(null).deletedAt(null)
-            .build();
-        given(commentService.createComment(any(CreateCommentRequest.class))).willReturn(
-            postCommentResponseDto);
+        doNothing().when(commentService)
+            .createComment(any(CreateCommentRequestDTO.class), any(Long.class));
         String json = new ObjectMapper().writeValueAsString(request);
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("MEMBER", 1L);
 
         // when, then
         mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/comment").content(json)
-            .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isCreated()).andDo(
-            document("comment-create", preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()), requestFields(
-                    fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자")
-                        .attributes(key("constraints").value(
-                            createCommentRequestConstraints.descriptionsForProperty("postId"))),
-                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 식별자")
-                        .attributes(key("constraints").value(
-                            createCommentRequestConstraints.descriptionsForProperty("memberId"))),
-                    fieldWithPath("content").type(JsonFieldType.STRING).description("내용")
-                        .attributes(key("constraints").value(
-                            createCommentRequestConstraints.descriptionsForProperty("content"))),
-                    fieldWithPath("anonymity").type(JsonFieldType.BOOLEAN).description("익명여부")
-                        .attributes(key("constraints").value(
-                            createCommentRequestConstraints.descriptionsForProperty("anonymity"))),
-                    fieldWithPath("parentCommentId").type(JsonFieldType.NUMBER).optional()
-                        .description("부모 댓글 식별자")), responseFields(
-                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
-                    fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
-                    fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답데이터"),
-                    fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("댓글 식별자"),
-                    fieldWithPath("data.memberId").type(JsonFieldType.NUMBER).description("회원 식별자"),
-                    fieldWithPath("data.nickname").type(JsonFieldType.STRING)
-                        .description("작성자 닉네임"),
-                    fieldWithPath("data.content").type(JsonFieldType.STRING).description("댓글 내용"),
-                    fieldWithPath("data.anonymity").type(JsonFieldType.BOOLEAN)
-                        .description("익명 여부"),
-                    fieldWithPath("data.parentCommentId").type(JsonFieldType.NUMBER).optional()
-                        .description("부모 댓글 식별자"),
-                    fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("등록 일시"),
-                    fieldWithPath("data.updatedAt").type(JsonFieldType.STRING).optional()
-                        .description("수정 일시"),
-                    fieldWithPath("data.deletedAt").type(JsonFieldType.STRING).optional()
-                        .description("삭제 일시"))));
+                .contentType(MediaType.APPLICATION_JSON).session(session))
+            .andExpect(status().isCreated()).andDo(
+                document("comment-create", preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()), requestFields(
+                        fieldWithPath("postId").type(JsonFieldType.NUMBER).description("게시글 식별자")
+                            .attributes(key("constraints").value(
+                                createCommentRequestConstraints.descriptionsForProperty("postId"))),
+                        fieldWithPath("content").type(JsonFieldType.STRING).description("내용")
+                            .attributes(key("constraints").value(
+                                createCommentRequestConstraints.descriptionsForProperty("content"))),
+                        fieldWithPath("anonymity").type(JsonFieldType.BOOLEAN).description("익명여부")
+                            .attributes(key("constraints").value(
+                                createCommentRequestConstraints.descriptionsForProperty("anonymity"))),
+                        fieldWithPath("parentCommentId").type(JsonFieldType.NUMBER).optional()
+                            .description("부모 댓글 식별자")), responseFields(
+                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+                        fieldWithPath("data").type(JsonFieldType.NULL).description("응답데이터"))));
     }
 
     @DisplayName("마이 페이지 댓글 목록 조회 API 문서화")
@@ -118,12 +100,13 @@ public class CommentControllerDocsTest extends RestDocsSupport {
             MyPageCommentResponseDTO.builder().id(3L).postId(2L).nickname("nickname1")
                 .content("아하!").anonymity(true).parentCommentId(1L).createdAt("2023-01-01 12:37:00")
                 .updatedAt(null).deletedAt(null).build()));
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("MEMBER", 1L);
 
         // when, then
-        mockMvc.perform(get("/api/v1/comment/my-page/{memberId}", 1)).andExpect(status().isOk())
+        mockMvc.perform(get("/api/v1/comment/my-page").session(session)).andExpect(status().isOk())
             .andDo(document("comments-search-mypage", preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                pathParameters(parameterWithName("memberId").description("회원 식별자")), responseFields(
+                preprocessResponse(prettyPrint()), responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
                     fieldWithPath("data").type(JsonFieldType.ARRAY).description("응답데이터"),
@@ -190,14 +173,9 @@ public class CommentControllerDocsTest extends RestDocsSupport {
     @Test
     void postUpdate() throws Exception {
         // given
-        UpdateCommentRequest request = UpdateCommentRequest.builder().id(1L).content("modified")
-            .build();
-        PostCommentResponseDTO postCommentResponseDto = PostCommentResponseDTO.builder().id(2L)
-            .memberId(2L).nickname("nickname2").content("감사합니다. -수정").anonymity(true)
-            .parentCommentId(1L).createdAt("2023-01-01 12:40:00").updatedAt("2023-01-01 12:41:00")
-            .deletedAt(null).build();
-        given(commentService.updateComment(any(UpdateCommentRequest.class))).willReturn(
-            postCommentResponseDto);
+        UpdateCommentRequestDTO request = UpdateCommentRequestDTO.builder().id(1L)
+            .content("modified").build();
+        doNothing().when(commentService).updateComment(any(UpdateCommentRequestDTO.class));
         String json = new ObjectMapper().writeValueAsString(request);
 
         // when, then
@@ -215,29 +193,16 @@ public class CommentControllerDocsTest extends RestDocsSupport {
                     responseFields(
                         fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
-                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답데이터"),
-                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("댓글 식별자"),
-                        fieldWithPath("data.memberId").type(JsonFieldType.NUMBER).description("회원 식별자"),
-                        fieldWithPath("data.nickname").type(JsonFieldType.STRING)
-                            .description("작성자 닉네임"),
-                        fieldWithPath("data.content").type(JsonFieldType.STRING).description("댓글 내용"),
-                        fieldWithPath("data.anonymity").type(JsonFieldType.BOOLEAN)
-                            .description("익명 여부"),
-                        fieldWithPath("data.parentCommentId").type(JsonFieldType.NUMBER).optional()
-                            .description("부모 댓글 식별자"),
-                        fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("등록 일시"),
-                        fieldWithPath("data.updatedAt").type(JsonFieldType.STRING).description("수정 일시"),
-                        fieldWithPath("data.deletedAt").type(JsonFieldType.STRING).optional()
-                            .description("삭제 일시"))));
+                        fieldWithPath("data").type(JsonFieldType.NULL).description("응답데이터"))));
     }
 
     @DisplayName("게시글 삭제 API 문서화")
     @Test
     void postDelete() throws Exception {
         // given
-        DeleteCommentRequest request = DeleteCommentRequest.builder().id(0L).build();
+        DeleteCommentRequestDTO request = DeleteCommentRequestDTO.builder().id(0L).build();
         String json = new ObjectMapper().writeValueAsString(request);
-        doNothing().when(commentService).deleteComment(any(DeleteCommentRequest.class));
+        doNothing().when(commentService).deleteComment(any(DeleteCommentRequestDTO.class));
 
         // when, then
         mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/comment").content(json)

--- a/src/test/java/com/fasttime/domain/comment/unit/service/CommentServiceTest.java
+++ b/src/test/java/com/fasttime/domain/comment/unit/service/CommentServiceTest.java
@@ -9,9 +9,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.fasttime.domain.comment.dto.request.CreateCommentRequest;
-import com.fasttime.domain.comment.dto.request.DeleteCommentRequest;
-import com.fasttime.domain.comment.dto.request.UpdateCommentRequest;
+import com.fasttime.domain.comment.dto.request.CreateCommentRequestDTO;
+import com.fasttime.domain.comment.dto.request.DeleteCommentRequestDTO;
+import com.fasttime.domain.comment.dto.request.UpdateCommentRequestDTO;
 import com.fasttime.domain.comment.dto.response.MyPageCommentResponseDTO;
 import com.fasttime.domain.comment.dto.response.PostCommentResponseDTO;
 import com.fasttime.domain.comment.entity.Comment;
@@ -61,24 +61,20 @@ public class CommentServiceTest {
         @DisplayName("비익명으로 댓글을 등록할 수 있다.")
         void nonAnonymous_willSuccess() {
             // given
-            CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
+            CreateCommentRequestDTO request = CreateCommentRequestDTO.builder().postId(1L)
                 .content("test").anonymity(false).parentCommentId(null).build();
-            Member member = Member.builder().id(0L).nickname("testNickname").build();
-            Comment comment = Comment.builder().id(0L).post(Post.builder().id(0L).build()).member(member).content("test")
-                .anonymity(false).parentComment(null).build();
-
-            given(postQueryService.findById(any(Long.class))).willReturn(PostDetailResponseDto.builder().id(0L).build());
+            Member member = Member.builder().id(1L).nickname("testNickname").build();
+            Comment comment = Comment.builder().id(1L).post(Post.builder().id(1L).build())
+                .member(member).content("test").anonymity(false).parentComment(null).build();
+            given(postQueryService.findById(any(Long.class))).willReturn(
+                PostDetailResponseDto.builder().id(0L).build());
             given(memberService.getMember(any(Long.class))).willReturn(member);
             given(commentRepository.save(any(Comment.class))).willReturn(comment);
 
             // when
-            PostCommentResponseDTO postCommentResponseDto = commentService.createComment(request);
+            commentService.createComment(request, 1L);
 
             // then
-            assertThat(postCommentResponseDto).extracting("id", "memberId", "nickname", "content",
-                    "anonymity", "parentCommentId")
-                .containsExactly(0L, 0L, "testNickname", "test", false, null);
-
             verify(postQueryService, times(1)).findById(any(Long.class));
             verify(memberService, times(1)).getMember(any(Long.class));
             verify(commentRepository, never()).findById(any(Long.class));
@@ -89,25 +85,21 @@ public class CommentServiceTest {
         @DisplayName("익명으로 댓글을 등록할 수 있다.")
         void anonymousComment_willSuccess() {
             // given
-            CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
+            CreateCommentRequestDTO request = CreateCommentRequestDTO.builder().postId(1L)
                 .content("test").anonymity(true).parentCommentId(null).build();
-            Post post = Post.builder().id(0L).build();
-            Member member = Member.builder().id(0L).nickname("testNickname").build();
-            Comment comment = Comment.builder().id(0L).post(post).member(member).content("test")
+            Post post = Post.builder().id(1L).build();
+            Member member = Member.builder().id(1L).nickname("testNickname").build();
+            Comment comment = Comment.builder().id(1L).post(post).member(member).content("test")
                 .anonymity(true).parentComment(null).build();
-
-            given(postQueryService.findById(any(Long.class))).willReturn(PostDetailResponseDto.builder().id(0L).build());
+            given(postQueryService.findById(any(Long.class))).willReturn(
+                PostDetailResponseDto.builder().id(1L).build());
             given(memberService.getMember(any(Long.class))).willReturn(member);
             given(commentRepository.save(any(Comment.class))).willReturn(comment);
 
             // when
-            PostCommentResponseDTO postCommentResponseDto = commentService.createComment(request);
+            commentService.createComment(request, 1L);
 
             // then
-            assertThat(postCommentResponseDto).extracting("id", "memberId", "nickname", "content",
-                    "anonymity", "parentCommentId")
-                .containsExactly(0L, 0L, "testNickname", "test", true, null);
-
             verify(postQueryService, times(1)).findById(any(Long.class));
             verify(memberService, times(1)).getMember(any(Long.class));
             verify(commentRepository, never()).findById(any(Long.class));
@@ -118,28 +110,25 @@ public class CommentServiceTest {
         @DisplayName("비익명으로 대댓글을 등록할 수 있다.")
         void nonAnonymousReply_willSuccess() {
             // given
-            CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
-                .content("test").anonymity(false).parentCommentId(0L).build();
-            Post post = Post.builder().id(0L).build();
-            Member member = Member.builder().id(0L).nickname("testNickname").build();
+            CreateCommentRequestDTO request = CreateCommentRequestDTO.builder().postId(1L)
+                .content("test").anonymity(false).parentCommentId(1L).build();
+            Post post = Post.builder().id(1L).build();
+            Member member = Member.builder().id(1L).nickname("testNickname").build();
             Optional<Comment> parentComment = Optional.of(
-                Comment.builder().id(0L).post(post).member(member).content("test").anonymity(false)
+                Comment.builder().id(1L).post(post).member(member).content("test").anonymity(false)
                     .parentComment(null).build());
             Comment comment = Comment.builder().id(1L).post(post).member(member).content("test")
                 .anonymity(false).parentComment(parentComment.get()).build();
-
             given(commentRepository.findById(any(Long.class))).willReturn(parentComment);
-            given(postQueryService.findById(any(Long.class))).willReturn(PostDetailResponseDto.builder().id(0L).build());
+            given(postQueryService.findById(any(Long.class))).willReturn(
+                PostDetailResponseDto.builder().id(1L).build());
             given(memberService.getMember(any(Long.class))).willReturn(member);
             given(commentRepository.save(any(Comment.class))).willReturn(comment);
+
             // when
-            PostCommentResponseDTO postCommentResponseDto = commentService.createComment(request);
+            commentService.createComment(request, 1L);
 
             // then
-            assertThat(postCommentResponseDto).extracting("id", "memberId", "nickname", "content",
-                    "anonymity", "parentCommentId")
-                .containsExactly(1L, 0L, "testNickname", "test", false, 0L);
-
             verify(postQueryService, times(1)).findById(any(Long.class));
             verify(memberService, times(1)).getMember(any(Long.class));
             verify(commentRepository, times(1)).findById(any(Long.class));
@@ -150,29 +139,25 @@ public class CommentServiceTest {
         @DisplayName("익명으로 대댓글을 등록할 수 있다.")
         void anonymousReply_willSuccess() {
             // given
-            CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
-                .content("test").anonymity(true).parentCommentId(0L).build();
-            Post post = Post.builder().id(0L).build();
-            Member member = Member.builder().id(0L).nickname("testNickname").build();
+            CreateCommentRequestDTO request = CreateCommentRequestDTO.builder().postId(1L)
+                .content("test").anonymity(true).parentCommentId(1L).build();
+            Post post = Post.builder().id(1L).build();
+            Member member = Member.builder().id(1L).nickname("testNickname").build();
             Optional<Comment> parentComment = Optional.of(
-                Comment.builder().id(0L).post(post).member(member).content("test").anonymity(false)
+                Comment.builder().id(1L).post(post).member(member).content("test").anonymity(false)
                     .parentComment(null).build());
             Comment comment = Comment.builder().id(1L).post(post).member(member).content("test")
                 .anonymity(true).parentComment(parentComment.get()).build();
-
             given(commentRepository.findById(any(Long.class))).willReturn(parentComment);
-            given(postQueryService.findById(any(Long.class))).willReturn(PostDetailResponseDto.builder().id(0L).build());
+            given(postQueryService.findById(any(Long.class))).willReturn(
+                PostDetailResponseDto.builder().id(1L).build());
             given(memberService.getMember(any(Long.class))).willReturn(member);
             given(commentRepository.save(any(Comment.class))).willReturn(comment);
 
             // when
-            PostCommentResponseDTO postCommentResponseDto = commentService.createComment(request);
+            commentService.createComment(request, 1L);
 
             // then
-            assertThat(postCommentResponseDto).extracting("id", "memberId", "nickname", "content",
-                    "anonymity", "parentCommentId")
-                .containsExactly(1L, 0L, "testNickname", "test", true, 0L);
-
             verify(postQueryService, times(1)).findById(any(Long.class));
             verify(memberService, times(1)).getMember(any(Long.class));
             verify(commentRepository, times(1)).findById(any(Long.class));
@@ -183,18 +168,16 @@ public class CommentServiceTest {
         @DisplayName("게시물을 찾을 수 없으면 댓글을 등록할 수 없다.")
         void postNotFound_willFail() {
             // given
-            CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
+            CreateCommentRequestDTO request = CreateCommentRequestDTO.builder().postId(1L)
                 .content("test").anonymity(false).parentCommentId(null).build();
-
             given(postQueryService.findById(any(Long.class))).willThrow(
                 new PostNotFoundException());
 
             // when, then
             Throwable exception = assertThrows(PostNotFoundException.class, () -> {
-                commentService.createComment(request);
+                commentService.createComment(request, 1L);
             });
             assertEquals("존재하지 않는 게시글입니다.", exception.getMessage());
-
             verify(commentRepository, never()).findById(any(Long.class));
             verify(commentRepository, never()).save(any(Comment.class));
         }
@@ -203,19 +186,18 @@ public class CommentServiceTest {
         @DisplayName("회원을 찾을 수 없으면 댓글을 등록할 수 없다.")
         void memberNotFound_willFail() {
             // given
-            CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
+            CreateCommentRequestDTO request = CreateCommentRequestDTO.builder().postId(1L)
                 .content("test").anonymity(false).parentCommentId(null).build();
-            Post post = Post.builder().id(0L).build();
-            given(postQueryService.findById(any(Long.class))).willReturn(PostDetailResponseDto.builder().id(0L).build());
+            given(postQueryService.findById(any(Long.class))).willReturn(
+                PostDetailResponseDto.builder().id(1L).build());
             given(memberService.getMember(any(Long.class))).willThrow(
-                new UserNotFoundException("User not found with id: 0L"));
+                new UserNotFoundException("User not found with id: 1L"));
 
             // when, then
             Throwable exception = assertThrows(UserNotFoundException.class, () -> {
-                commentService.createComment(request);
+                commentService.createComment(request, 1L);
             });
-            assertEquals("User not found with id: 0L", exception.getMessage());
-
+            assertEquals("User not found with id: 1L", exception.getMessage());
             verify(postQueryService, times(1)).findById(any(Long.class));
             verify(memberService, times(1)).getMember(any(Long.class));
             verify(commentRepository, never()).findById(any(Long.class));
@@ -226,17 +208,15 @@ public class CommentServiceTest {
         @DisplayName("댓글을 찾을 수 없으면 대댓글을 등록할 수 없다.")
         void parentCommentNotFound_willFail() {
             // given
-            CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
-                .content("test").anonymity(false).parentCommentId(0L).build();
-
+            CreateCommentRequestDTO request = CreateCommentRequestDTO.builder().postId(1L)
+                .content("test").anonymity(false).parentCommentId(1L).build();
             given(commentRepository.findById(any(Long.class))).willReturn(Optional.empty());
 
             // when, then
             Throwable exception = assertThrows(CommentNotFoundException.class, () -> {
-                commentService.createComment(request);
+                commentService.createComment(request, 1L);
             });
             assertEquals("존재하지 않는 댓글입니다.", exception.getMessage());
-
             verify(commentRepository, times(1)).findById(any(Long.class));
             verify(commentRepository, never()).save(any(Comment.class));
         }
@@ -250,23 +230,19 @@ public class CommentServiceTest {
         @DisplayName("댓글을 수정할 수 있다.")
         void _willSuccess() {
             // given
-            UpdateCommentRequest request = UpdateCommentRequest.builder().id(0L).content("modified")
-                .build();
-            Post post = Post.builder().id(0L).build();
-            Member member = Member.builder().id(0L).nickname("testNickname").build();
+            UpdateCommentRequestDTO request = UpdateCommentRequestDTO.builder().id(1L)
+                .content("modified").build();
+            Post post = Post.builder().id(1L).build();
+            Member member = Member.builder().id(1L).nickname("testNickname").build();
             Optional<Comment> comment = Optional.of(
-                Comment.builder().id(0L).post(post).member(member).content("test").anonymity(false)
+                Comment.builder().id(1L).post(post).member(member).content("test").anonymity(false)
                     .parentComment(null).build());
             given(commentRepository.findById(any(Long.class))).willReturn(comment);
 
             // when
-            PostCommentResponseDTO postCommentResponseDto = commentService.updateComment(request);
+            commentService.updateComment(request);
 
             // then
-            assertThat(postCommentResponseDto).extracting("id", "memberId", "nickname", "content",
-                    "anonymity", "parentCommentId")
-                .containsExactly(0L, 0L, "testNickname", "modified", false, null);
-
             verify(commentRepository, times(1)).findById(any(Long.class));
         }
 
@@ -274,10 +250,9 @@ public class CommentServiceTest {
         @DisplayName("댓글을 찾을 수 없으면 댓글을 가져올 수 없다.")
         void CommentNotFound_willFail() {
             // given
-            UpdateCommentRequest request = UpdateCommentRequest.builder().id(0L).content("modified")
-                .build();
+            UpdateCommentRequestDTO request = UpdateCommentRequestDTO.builder().id(0L)
+                .content("modified").build();
             Optional<Comment> comment = Optional.empty();
-
             given(commentRepository.findById(any(Long.class))).willReturn(comment);
 
             // when, then
@@ -285,7 +260,6 @@ public class CommentServiceTest {
                 commentService.updateComment(request);
             });
             assertEquals("존재하지 않는 댓글입니다.", exception.getMessage());
-
             verify(commentRepository, times(1)).findById(any(Long.class));
         }
     }
@@ -298,13 +272,12 @@ public class CommentServiceTest {
         @DisplayName("댓글을 삭제할 수 있다.")
         void _willSuccess() {
             // given
-            DeleteCommentRequest request = DeleteCommentRequest.builder().id(0L).build();
-            Post post = Post.builder().id(0L).build();
-            Member member = Member.builder().id(0L).nickname("testNickname").build();
+            DeleteCommentRequestDTO request = DeleteCommentRequestDTO.builder().id(0L).build();
+            Post post = Post.builder().id(1L).build();
+            Member member = Member.builder().id(1L).nickname("testNickname").build();
             Optional<Comment> comment = Optional.of(
-                Comment.builder().id(0L).post(post).member(member).content("test").anonymity(false)
+                Comment.builder().id(1L).post(post).member(member).content("test").anonymity(false)
                     .parentComment(null).build());
-
             given(commentRepository.findById(any(Long.class))).willReturn(comment);
 
             // when
@@ -318,9 +291,8 @@ public class CommentServiceTest {
         @DisplayName("댓글을 찾을 수 없으면 댓글을 삭제할 수 없다.")
         void CommentNotFound_willFail() {
             // given
-            DeleteCommentRequest request = DeleteCommentRequest.builder().id(0L).build();
+            DeleteCommentRequestDTO request = DeleteCommentRequestDTO.builder().id(1L).build();
             Optional<Comment> comment = Optional.empty();
-
             given(commentRepository.findById(any(Long.class))).willReturn(comment);
 
             // when, then
@@ -328,7 +300,6 @@ public class CommentServiceTest {
                 commentService.deleteComment(request);
             });
             assertEquals("존재하지 않는 댓글입니다.", exception.getMessage());
-
             verify(commentRepository, times(1)).findById(any(Long.class));
         }
     }
@@ -341,20 +312,20 @@ public class CommentServiceTest {
         @DisplayName("댓글을 가져올 수 있다.")
         void _willSuccess() {
             // given
-            Post post = Post.builder().id(0L).build();
-            Member member = Member.builder().id(0L).build();
+            Post post = Post.builder().id(1L).build();
+            Member member = Member.builder().id(1L).build();
             Optional<Comment> comment = Optional.of(
-                Comment.builder().id(0L).post(post).member(member).content("test").anonymity(false)
+                Comment.builder().id(1L).post(post).member(member).content("test").anonymity(false)
                     .parentComment(null).build());
 
             given(commentRepository.findById(any(Long.class))).willReturn(comment);
 
             // when
-            Comment result = commentService.getComment(0L);
+            Comment result = commentService.getComment(1L);
 
             // then
             assertThat(result).extracting("id", "post", "member", "content", "anonymity",
-                "parentComment").containsExactly(0L, post, member, "test", false, null);
+                "parentComment").containsExactly(1L, post, member, "test", false, null);
 
             verify(commentRepository, times(1)).findById(any(Long.class));
         }
@@ -369,7 +340,7 @@ public class CommentServiceTest {
 
             // when, then
             Throwable exception = assertThrows(CommentNotFoundException.class, () -> {
-                commentService.getComment(0L);
+                commentService.getComment(1L);
             });
             assertEquals("존재하지 않는 댓글입니다.", exception.getMessage());
 
@@ -386,16 +357,15 @@ public class CommentServiceTest {
         @DisplayName("해당 게시글의 댓글들을 불러올 수 있다.")
         void _willSuccess() {
             // given
-            Post post = Post.builder().id(0L).build();
-            Member member = Member.builder().id(0L).build();
-            Comment comment = Comment.builder().id(0L).post(post).member(member).content("test")
+            Post post = Post.builder().id(1L).build();
+            Member member = Member.builder().id(1L).build();
+            Comment comment = Comment.builder().id(1L).post(post).member(member).content("test")
                 .anonymity(false).parentComment(null).build();
             List<Comment> commentList = new ArrayList<>();
             commentList.add(comment);
             Optional<List<Comment>> comments = Optional.of(commentList);
             List<PostCommentResponseDTO> commentDTOList = new ArrayList<>();
             commentDTOList.add(comment.toPostCommentResponseDTO());
-
             given(commentRepository.findAllByPost(any(Post.class))).willReturn(comments);
 
             // when
@@ -405,7 +375,6 @@ public class CommentServiceTest {
             assertThat(result.get(0).getId()).isEqualTo(commentDTOList.get(0).getId());
             assertThat(
                 result.get(0).getContent().equals(commentDTOList.get(0).getContent())).isTrue();
-
             verify(commentRepository, times(1)).findAllByPost(any(Post.class));
         }
 
@@ -413,9 +382,8 @@ public class CommentServiceTest {
         @DisplayName("댓글을 찾을 수 없으면 빈 리스트를 반환한다.")
         void CommentNotFound_willFail() {
             // given
-            Post post = Post.builder().id(0L).build();
+            Post post = Post.builder().id(1L).build();
             Optional<List<Comment>> comments = Optional.empty();
-
             given(commentRepository.findAllByPost(any(Post.class))).willReturn(comments);
 
             // when
@@ -423,7 +391,6 @@ public class CommentServiceTest {
 
             // then
             assertThat(result).isEmpty();
-
             verify(commentRepository, times(1)).findAllByPost(any(Post.class));
         }
     }
@@ -436,11 +403,10 @@ public class CommentServiceTest {
         @DisplayName("해당 회원의 댓글들을 불러올 수 있다.")
         void _willSuccess() {
             // given
-            Post post = Post.builder().id(0L).build();
-            Member member = Member.builder().id(0L).build();
-            Comment comment = Comment.builder().id(0L).post(post).member(member).content("test")
+            Post post = Post.builder().id(1L).build();
+            Member member = Member.builder().id(1L).build();
+            Comment comment = Comment.builder().id(1L).post(post).member(member).content("test")
                 .anonymity(false).parentComment(null).build();
-
             List<Comment> commentList = new ArrayList<>();
             commentList.add(comment);
             Optional<List<Comment>> comments = Optional.of(commentList);
@@ -457,7 +423,6 @@ public class CommentServiceTest {
             assertThat(result.get(0).getId()).isEqualTo(commentDTOList.get(0).getId());
             assertThat(
                 result.get(0).getContent().equals(commentDTOList.get(0).getContent())).isTrue();
-
             verify(commentRepository, times(1)).findAllByMember(any(Member.class));
         }
 
@@ -465,9 +430,8 @@ public class CommentServiceTest {
         @DisplayName("댓글을 찾을 수 없으면 빈 리스트를 반환한다.")
         void CommentNotFound_willFail() {
             // given
-            Member member = Member.builder().id(0L).build();
+            Member member = Member.builder().id(1L).build();
             Optional<List<Comment>> comments = Optional.empty();
-
             given(commentRepository.findAllByMember(any(Member.class))).willReturn(comments);
 
             // when
@@ -475,7 +439,6 @@ public class CommentServiceTest {
 
             // then
             assertThat(result).isEmpty();
-
             verify(commentRepository, times(1)).findAllByMember(any(Member.class));
         }
     }


### PR DESCRIPTION
### 개발 내용
- 댓글 API 수정
  - 댓글 등록, 마이페이지 조회 시 memberId를 필드나 파라미터가 아닌 세션에서 가져옴
  - 댓글 등록, 삭제 시 댓글 DTO를 응답하지 않도록 수정
- 댓글 Service, Controller  리팩토링
- 댓글 테스트 코드 수정
- 댓글 REST Docs 수정