### PR TITLE
[refactor] 익셉션 핸들링 분기처리

### DIFF
--- a/src/main/java/com/fasttime/global/exception/GlobalExceptionRestAdvice.java
+++ b/src/main/java/com/fasttime/global/exception/GlobalExceptionRestAdvice.java
@@ -2,6 +2,7 @@ package com.fasttime.global.exception;
 
 import com.fasttime.global.util.ResponseDTO;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
@@ -30,10 +31,18 @@ public class GlobalExceptionRestAdvice {
     }
 
     @ExceptionHandler
+    public ResponseEntity<ResponseDTO<Object>> dbException(DataAccessException e) {
+        log.error("Database Error : " + e.getMessage());
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ResponseDTO.res(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러!"));
+    }
+
+    @ExceptionHandler
     public ResponseEntity<ResponseDTO<Object>> serverException(RuntimeException e) {
         log.error("Server Exception: " + e.getMessage());
         return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(ResponseDTO.res(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러!"));
     }
 }


### PR DESCRIPTION
Motivation:
- spring 에서는 checked exception인 `SQLException`를 unchecked exception `DataAccessException` 으로 변환하는 기술을 제공합니다. ExceptionHandler 에서 해당 방식을 추가합니다.

- `serverException` 에서 `BAD_REQUEST`를 httpStatus로 전달하는 것을 확인했습니다. 이를 `INTERNAL_SERVER_ERROR` 로 변경하고자 합니다.

Modification:

- `DataAccessException` handling 추가
- `serverException` 에서 `BAD_REQUEST` 를 던지던 것을 `INTERNAL_SERVER_ERROR`로 변경