### PR TITLE
[fix] likeCount 누락 수정

### DIFF
--- a/src/main/java/com/fasttime/domain/post/entity/Post.java
+++ b/src/main/java/com/fasttime/domain/post/entity/Post.java
@@ -46,10 +46,8 @@ public class Post extends BaseTimeEntity {
 
     private boolean anonymity;
 
-//    @Formula("(SELECT COALESCE(COUNT(1), 0) FROM record r WHERE r.post_id = id GROUP BY r.type HAVING r.type = true)")
     private int likeCount;
 
-//    @Formula("(SELECT COALESCE(COUNT(1), 0) FROM record r WHERE r.post_id = id GROUP BY r.type HAVING r.type = false)")
     private int hateCount;
 
     @Enumerated(EnumType.STRING)
@@ -68,7 +66,8 @@ public class Post extends BaseTimeEntity {
         this.reportStatus = reportStatus;
     }
 
-    public static Post createNewPost(Member member, String title, String content, boolean anonymity) {
+    public static Post createNewPost(Member member, String title, String content,
+        boolean anonymity) {
         return Post.builder()
             .member(member)
             .title(title)
@@ -82,11 +81,14 @@ public class Post extends BaseTimeEntity {
 
     public void update(String title, String content) {
         if (reportStatus.equals(ReportStatus.REPORTED)) {
-            throw new PostReportedException(String.format("This post is reported. So cannot update this post. / requestPostId = %d", this.id));
+            throw new PostReportedException(String.format(
+                "This post is reported. So cannot update this post. / requestPostId = %d",
+                this.id));
         }
 
         if (this.isDeleted()) {
-            throw new PostDeletedException(String.format("This post is deleted. So cannot update this post. / requestPostId = %d", this.id));
+            throw new PostDeletedException(String.format(
+                "This post is deleted. So cannot update this post. / requestPostId = %d", this.id));
         }
 
         this.title = title;
@@ -102,19 +104,19 @@ public class Post extends BaseTimeEntity {
         super.delete(currentTime);
     }
 
-    public void like(boolean increase) {
-        if (increase) {
-            this.likeCount++;
+    public void likeOrHate(boolean isLike, boolean increase) {
+        if (isLike) {
+            if (increase) {
+                this.likeCount++;
+            } else {
+                this.likeCount--;
+            }
         } else {
-            this.likeCount--;
-        }
-    }
-
-    public void hate(boolean increase) {
-        if (increase) {
-            this.hateCount++;
-        } else {
-            this.hateCount--;
+            if (increase) {
+                this.hateCount++;
+            } else {
+                this.hateCount--;
+            }
         }
     }
 

--- a/src/main/java/com/fasttime/domain/post/service/PostCommandService.java
+++ b/src/main/java/com/fasttime/domain/post/service/PostCommandService.java
@@ -63,6 +63,12 @@ public class PostCommandService implements PostCommandUseCase {
         post.delete(serviceDto.getDeletedAt());
     }
 
+    @Override
+    public void likeOrHatePost(PostLikeOrHateServiceDto serviceDto) {
+        Post post = findPostById(serviceDto.getPostId());
+        post.likeOrHate(serviceDto.isLike(), serviceDto.isIncrease());
+    }
+
     private Post findPostById(Long postId) {
         return postRepository.findById(postId)
             .orElseThrow(() -> new PostNotFoundException(

--- a/src/main/java/com/fasttime/domain/post/service/PostCommandUseCase.java
+++ b/src/main/java/com/fasttime/domain/post/service/PostCommandUseCase.java
@@ -14,6 +14,8 @@ public interface PostCommandUseCase {
 
     void deletePost(PostDeleteServiceDto serviceDto);
 
+    void likeOrHatePost(PostLikeOrHateServiceDto serviceDto);
+
     @Getter
     class PostCreateServiceDto {
 
@@ -63,6 +65,20 @@ public interface PostCommandUseCase {
             this.postId = postId;
             this.memberId = memberId;
             this.deletedAt = deletedAt;
+        }
+    }
+
+    @Getter
+    class PostLikeOrHateServiceDto {
+
+        private Long postId;
+        private boolean isLike;
+        private boolean increase;
+
+        public PostLikeOrHateServiceDto(Long postId, boolean isLike, boolean increase) {
+            this.postId = postId;
+            this.isLike = isLike;
+            this.increase = increase;
         }
     }
 

--- a/src/main/java/com/fasttime/domain/record/service/RecordService.java
+++ b/src/main/java/com/fasttime/domain/record/service/RecordService.java
@@ -4,6 +4,8 @@ import com.fasttime.domain.member.entity.Member;
 import com.fasttime.domain.member.service.MemberService;
 import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
+import com.fasttime.domain.post.service.PostCommandService;
+import com.fasttime.domain.post.service.PostCommandUseCase.PostLikeOrHateServiceDto;
 import com.fasttime.domain.post.service.PostQueryService;
 import com.fasttime.domain.record.dto.RecordDTO;
 import com.fasttime.domain.record.dto.request.CreateRecordRequestDTO;
@@ -30,6 +32,7 @@ public class RecordService {
 
     private final RecordRepository recordRepository;
     private final PostQueryService postQueryService;
+    private final PostCommandService postCommandService;
     private final MemberService memberService;
 
     public void createRecord(CreateRecordRequestDTO createRecordRequestDTO, Long memberId) {
@@ -42,6 +45,9 @@ public class RecordService {
         recordRepository.save(
             Record.builder().member(member).post(Post.builder().id(postResponse.getId()).build())
                 .isLike(createRecordRequestDTO.getIsLike()).build());
+
+        postCommandService.likeOrHatePost(new PostLikeOrHateServiceDto(postResponse.getId(),
+            createRecordRequestDTO.getIsLike(), true));
     }
 
     public RecordDTO getRecord(long memberId, long postId) {

--- a/src/test/java/com/fasttime/domain/record/unit/service/RecordServiceTest.java
+++ b/src/test/java/com/fasttime/domain/record/unit/service/RecordServiceTest.java
@@ -12,6 +12,8 @@ import com.fasttime.domain.member.entity.Member;
 import com.fasttime.domain.member.service.MemberService;
 import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
+import com.fasttime.domain.post.service.PostCommandService;
+import com.fasttime.domain.post.service.PostCommandUseCase.PostLikeOrHateServiceDto;
 import com.fasttime.domain.post.service.PostQueryService;
 import com.fasttime.domain.record.dto.RecordDTO;
 import com.fasttime.domain.record.dto.request.CreateRecordRequestDTO;
@@ -49,6 +51,9 @@ public class RecordServiceTest {
     private PostQueryService postQueryService;
 
     @Mock
+    private PostCommandService postCommandService;
+
+    @Mock
     private MemberService memberService;
 
     @Nested
@@ -75,6 +80,7 @@ public class RecordServiceTest {
 
             // then
             verify(recordRepository, times(1)).save(any(Record.class));
+            verify(postCommandService, times(1)).likeOrHatePost(any(PostLikeOrHateServiceDto.class));
         }
 
         @Test
@@ -97,6 +103,7 @@ public class RecordServiceTest {
 
             // then
             verify(recordRepository, times(1)).save(any(Record.class));
+            verify(postCommandService, times(1)).likeOrHatePost(any(PostLikeOrHateServiceDto.class));
         }
 
         @Test


### PR DESCRIPTION
Motivation:
- 1차적으로 RecordService 에서 post의 likeCount를 수정할 수 있게끔 추가했습니다.

Modification:

- `likeOrHate` 로직 추가