### PR TITLE
[feature] 삭제된 게시글을 쿼리하지 않는다.

### DIFF
--- a/src/main/java/com/fasttime/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/fasttime/domain/post/repository/PostRepositoryImpl.java
@@ -35,7 +35,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
             ))
             .from(post)
             .where(createSearchConditionBuilder(postSearchCondition))
-            .offset(postSearchCondition.getPage())
+            .offset((long) postSearchCondition.getPage() * postSearchCondition.getPageSize())
             .limit(postSearchCondition.getPageSize())
             .orderBy(post.createdAt.desc())
             .fetch();
@@ -55,6 +55,8 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         if (searchCondition.getLikeCount() > 0) {
             booleanBuilder.and(post.likeCount.gt(searchCondition.getLikeCount()));
         }
+
+        booleanBuilder.and(post.deletedAt.isNull());
 
         return booleanBuilder;
     }

--- a/src/main/java/com/fasttime/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fasttime/domain/post/service/PostQueryService.java
@@ -30,7 +30,6 @@ public class PostQueryService implements PostQueryUseCase {
     public List<PostsResponseDto> searchPost(PostSearchCondition postSearchCondition) {
         return postRepository.search(postSearchCondition)
             .stream()
-            .filter(respositoryDto -> respositoryDto.getDeletedAt() == null)
             .map(repositoryDto -> PostsResponseDto.builder()
                 .id(repositoryDto.getId())
                 .title(repositoryDto.getTitle())


### PR DESCRIPTION
Motivation:
- 전체 쿼리를 수행한 후 `deletedAt is not null` 을 필터링하다 보니, 요청된 pageSize에 맞게 반환하지 못하는 현상을 발견했습니다.

Modification:
- 쿼리를 할 때 `deletedAt is not null` 조건을 사용하기로 변경했습니다.