### PR TITLE
[refactor] BindingResult 삭제 및 orElseThrow() 사용

### DIFF
--- a/src/main/java/com/fasttime/domain/member/controller/AdminController.java
+++ b/src/main/java/com/fasttime/domain/member/controller/AdminController.java
@@ -41,7 +41,7 @@ public class AdminController {
 
     @GetMapping("/{post_id}/delete") // 문제가 있는 Post를 삭제
     public ResponseEntity<ResponseDTO> deletePost
-        (@PathVariable("post_id") Long post_id) throws AccessException {
+        (@PathVariable("post_id") Long post_id) {
         adminService.deletePost(post_id);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.res(HttpStatus.OK
             , "신고가 10번이상된 게시글을 삭제합니다."));
@@ -49,7 +49,7 @@ public class AdminController {
 
     @GetMapping("/{post_id}/pass") // 문제가 없는 Post 검토완료로 변경
     public ResponseEntity<ResponseDTO> passPost
-        (@PathVariable("post_id") Long post_id) throws AccessException {
+        (@PathVariable("post_id") Long post_id) {
         adminService.passPost(post_id);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.res(HttpStatus.OK
             , "신고가 10번이상된 게시글을 복구합니다."));

--- a/src/main/java/com/fasttime/domain/member/controller/MemberController.java
+++ b/src/main/java/com/fasttime/domain/member/controller/MemberController.java
@@ -1,11 +1,8 @@
 package com.fasttime.domain.member.controller;
 
+import com.fasttime.domain.member.dto.MemberDto;
 import com.fasttime.domain.member.dto.request.LoginRequestDTO;
 import com.fasttime.domain.member.entity.Member;
-import com.fasttime.domain.member.dto.MemberDto;
-
-
-import com.fasttime.domain.member.exception.UserNotFoundException;
 import com.fasttime.domain.member.repository.MemberRepository;
 import com.fasttime.domain.member.request.EditRequest;
 import com.fasttime.domain.member.request.RePasswordRequest;
@@ -13,19 +10,21 @@ import com.fasttime.domain.member.response.EditResponse;
 import com.fasttime.domain.member.response.MemberResponse;
 import com.fasttime.domain.member.service.MemberService;
 import com.fasttime.global.util.ResponseDTO;
-import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import javax.servlet.http.HttpSession;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindException;
-import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
-import javax.validation.Valid;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
 
 @RestController
@@ -152,11 +151,8 @@ public class MemberController {
 
     @PostMapping("/api/v1/login")
     public ResponseEntity<ResponseDTO> logIn(@Validated @RequestBody LoginRequestDTO dto
-        , BindingResult bindingResult, HttpSession session)
-        throws UserNotFoundException, BindException {
-        if (bindingResult.hasErrors()) {
-            throw new BindException(bindingResult);
-        }
+        ,HttpSession session) throws Exception {
+
         MemberResponse response = memberService.loginMember(dto);
         session.setAttribute("MEMBER", response.getId());
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.res
@@ -177,12 +173,8 @@ public class MemberController {
 
     @PostMapping("/api/v1/RePassword")
     public ResponseEntity<ResponseDTO> rePassword
-        (@Validated @RequestBody RePasswordRequest request, BindingResult bindingResult
-            , HttpSession session)
-        throws BindException {
-        if (bindingResult.hasErrors()) {
-            throw new BindException(bindingResult);
-        }
+        (@Validated @RequestBody RePasswordRequest request, HttpSession session) {
+
         MemberResponse response =
             memberService.rePassword(request, (Long) session.getAttribute("MEMBER"));
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDTO.res

--- a/src/main/java/com/fasttime/domain/member/controller/MemberController.java
+++ b/src/main/java/com/fasttime/domain/member/controller/MemberController.java
@@ -151,7 +151,7 @@ public class MemberController {
 
     @PostMapping("/api/v1/login")
     public ResponseEntity<ResponseDTO> logIn(@Validated @RequestBody LoginRequestDTO dto
-        ,HttpSession session) throws Exception {
+        ,HttpSession session) {
 
         MemberResponse response = memberService.loginMember(dto);
         session.setAttribute("MEMBER", response.getId());

--- a/src/main/java/com/fasttime/domain/member/service/MemberService.java
+++ b/src/main/java/com/fasttime/domain/member/service/MemberService.java
@@ -70,16 +70,17 @@ public class MemberService {
     }
 
     public MemberResponse loginMember(LoginRequestDTO dto) throws UserNotFoundException {
-        Optional<Member> byEmail = memberRepository.findByEmail(dto.getEmail());
-        if (!byEmail.isPresent()) {
-            throw new UserNotFoundException("User not found with email: " + dto.getEmail());
+        Member member = memberRepository.findByEmail(dto.getEmail()).orElseThrow(
+            () -> new UserNotFoundException("User not found with email: " + dto.getEmail()));
+        if (member.getDeletedAt() != null) {
+            throw new UserNotFoundException("이미 탈퇴한 계정입니다");
         }
-        Member member = byEmail.get();
+
         if (!passwordEncoder.matches(dto.getPassword(), member.getPassword())) {
             throw new BadCredentialsException("Not match password!");
-        } else {
-            return new MemberResponse(member.getId(), member.getNickname());
         }
+        return new MemberResponse(member.getId(), member.getNickname());
+
     }
 
     public MemberResponse rePassword(RePasswordRequest request, Long id) {
@@ -87,9 +88,9 @@ public class MemberService {
             Member member = memberRepository.findById(id).get();
             member.setPassword(passwordEncoder.encode(request.getPassword()));
             return new MemberResponse(member.getId(), member.getNickname());
-        } else {
-            throw new BadCredentialsException("Not Match RePassword!");
         }
+        throw new BadCredentialsException("Not Match RePassword!");
+
     }
 
 


### PR DESCRIPTION
# 내용
- ControllerAdvice에서 bindException를 처리하고 있으므로, 기존 코드에 있던 BindingResult를 삭제하였습니다.
- AdminService에서 orElseThrow() 메소드를 활용하여, 예외를 발생시키는 코드를 압축하였습니다.
- MemberService에서 불필요한 Else문을 삭제하였습니다.
- 로그인 시, 논리 삭제된 멤버는 로그인을 하지 못하도록 수정하였습니다.