### PR TITLE
[fix] 누락된 login interceptor `PathPattern` 추가

### DIFF
--- a/src/main/java/com/fasttime/global/config/WebConfig.java
+++ b/src/main/java/com/fasttime/global/config/WebConfig.java
@@ -22,6 +22,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(new LoginCheckInterceptor())
             .order(2)
             .addPathPatterns("/api/v1/comment", "/api/v1/my-page/**", "/api/v1/post",
+                "/api/v1/report/**", "/api/v1/record/**",
                 "/api/v1/retouch-member", "/api/v1/logout", "/api/v1/delete","/api/v1/RePassword");
 
     }


### PR DESCRIPTION
Motivation:
- 좋아요/싫어요 및 신고 API가 login interceptor의 `PathPattern`에 누락되어 로그인 관련 분기처리가 제대로 되지 않는 문제가 발생했습니다. 이를 해결하기 위해 댓글 API 경로를`PathPattern`를 추가했습니다.

Modification:
- `WebConfig.java`에서 LoginInterceptor addPathPatterns() 에 report, record api 경로 추가