### PR TITLE
[feature] 게시글 댓글 갯수 쿼리 기능 추가

### DIFF
--- a/src/main/java/com/fasttime/domain/post/entity/Post.java
+++ b/src/main/java/com/fasttime/domain/post/entity/Post.java
@@ -1,10 +1,13 @@
 package com.fasttime.domain.post.entity;
 
+import com.fasttime.domain.comment.entity.Comment;
 import com.fasttime.domain.member.entity.Member;
 import com.fasttime.domain.post.exception.PostDeletedException;
 import com.fasttime.domain.post.exception.PostReportedException;
 import com.fasttime.global.common.BaseTimeEntity;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -15,6 +18,7 @@ import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -38,6 +42,9 @@ public class Post extends BaseTimeEntity {
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "post")
+    private List<Comment> comments = new ArrayList<>();
 
     private String title;
 

--- a/src/main/java/com/fasttime/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/fasttime/domain/post/repository/PostRepositoryCustom.java
@@ -17,6 +17,7 @@ public interface PostRepositoryCustom {
         private String nickname;
         private String title;
         private boolean anonymity;
+        private int commentCount;
         private int likeCount;
         private int hateCount;
         private LocalDateTime createdAt;

--- a/src/main/java/com/fasttime/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/fasttime/domain/post/repository/PostRepositoryImpl.java
@@ -27,6 +27,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 post.member.nickname,
                 post.title,
                 post.anonymity,
+                post.comments.size().as("commentCount"),
                 post.likeCount,
                 post.hateCount,
                 post.createdAt,

--- a/src/main/java/com/fasttime/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fasttime/domain/post/service/PostQueryService.java
@@ -37,6 +37,7 @@ public class PostQueryService implements PostQueryUseCase {
                 .anonymity(repositoryDto.isAnonymity())
                 .likeCount(repositoryDto.getLikeCount())
                 .hateCount(repositoryDto.getHateCount())
+                .commentCounts(repositoryDto.getCommentCount())
                 .createdAt(repositoryDto.getCreatedAt())
                 .lastModifiedAt(repositoryDto.getLastModifiedAt())
                 .build())


### PR DESCRIPTION
Motivation:
- 게시글 목록에서 댓글 갯수를 가져올 수 있도록 쿼리를 추가합니다.

Modification:
- `Post` entity 에서 `List<Comment>` 연관관계 추가
- 댓글 수를 가져오는 querydsl 코드 추가.
- `PostsResponseDto` 에서 `commentCount` 추가