### PR TITLE
[feat] 탈퇴 계정 유효기간 설정 및 계정 복구 추가

### DIFF
--- a/src/docs/asciidoc/member/member-api.adoc
+++ b/src/docs/asciidoc/member/member-api.adoc
@@ -58,7 +58,7 @@ include::{snippets}/member-rePassword/response-fields.adoc[]
 [[Member-Join]]
 == 회원 가입
 
-회원 가입 API 입니다.
+회원 가입, 탈퇴 계정 복구 API 입니다.
 
 
 === HttpRequest
@@ -69,7 +69,10 @@ include::{snippets}/member-join/request-fields.adoc[]
 === HttpResponse
 
 include::{snippets}/member-join/http-response.adoc[]
+include::{snippets}/member-restore/http-response.adoc[]
 include::{snippets}/member-join/response-fields.adoc[]
+
+
 
 [[Member-Delete]]
 == 회원 탈퇴
@@ -116,6 +119,9 @@ include::{snippets}/member-update/http-request.adoc[]
 
 include::{snippets}/member-update/http-response.adoc[]
 include::{snippets}/member-update/response-fields.adoc[]
+
+
+
 
 
 

--- a/src/main/java/com/fasttime/domain/member/entity/Member.java
+++ b/src/main/java/com/fasttime/domain/member/entity/Member.java
@@ -38,9 +38,14 @@ public class Member extends BaseTimeEntity {
     public void delete(LocalDateTime currentTime) {
         super.delete(currentTime);
     }
+    public void recover() {
+        super.restore();
+    }
 
     @Column(name = "image", columnDefinition = "TEXT")
     private String image;
+
+
 
 
 }

--- a/src/main/java/com/fasttime/domain/member/entity/Member.java
+++ b/src/main/java/com/fasttime/domain/member/entity/Member.java
@@ -38,14 +38,14 @@ public class Member extends BaseTimeEntity {
     public void delete(LocalDateTime currentTime) {
         super.delete(currentTime);
     }
-    public void recover() {
+
+    @Override
+    public void restore() {
         super.restore();
     }
 
     @Column(name = "image", columnDefinition = "TEXT")
     private String image;
-
-
 
 
 }

--- a/src/main/java/com/fasttime/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/fasttime/domain/member/repository/MemberRepository.java
@@ -4,9 +4,11 @@ import com.fasttime.domain.member.entity.Member;
 import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 
-public interface MemberRepository extends JpaRepository<Member, Long>{
+public interface MemberRepository extends JpaRepository<Member, Long> {
 
 
     Optional<Member> findByNickname(String nickname);
@@ -17,10 +19,9 @@ public interface MemberRepository extends JpaRepository<Member, Long>{
 
     void deleteByDeletedAtBefore(LocalDateTime dateTime);
 
-    Optional<Member> findByEmailAndDeletedAtBefore(String email, LocalDateTime dateTime);
-
-
-
+    @Query("SELECT m FROM Member m WHERE m.email = :email AND m.deletedAt > :dateTime")
+    Optional<Member> findSoftDeletedByEmail(@Param("email") String email,
+        @Param("dateTime") LocalDateTime dateTime);
 
 
 }

--- a/src/main/java/com/fasttime/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/fasttime/domain/member/repository/MemberRepository.java
@@ -17,5 +17,10 @@ public interface MemberRepository extends JpaRepository<Member, Long>{
 
     void deleteByDeletedAtBefore(LocalDateTime dateTime);
 
+    Optional<Member> findByEmailAndDeletedAtBefore(String email, LocalDateTime dateTime);
+
+
+
+
 
 }

--- a/src/main/java/com/fasttime/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/fasttime/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.fasttime.domain.member.repository;
 
 import com.fasttime.domain.member.entity.Member;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
@@ -13,4 +14,8 @@ public interface MemberRepository extends JpaRepository<Member, Long>{
     Optional<Member> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    void deleteByDeletedAtBefore(LocalDateTime dateTime);
+
+
 }

--- a/src/main/java/com/fasttime/domain/member/service/MemberService.java
+++ b/src/main/java/com/fasttime/domain/member/service/MemberService.java
@@ -50,8 +50,9 @@ public class MemberService {
     }
 
     public boolean isEmailExistsInMember(String email) {
-        return memberRepository.existsByEmail(email);
+        return memberRepository.existsByEmail(email); // 저장소에 existsByEmail 메소드가 있다고 가정합니다.
     }
+
 
 
     public void save(Member member) {

--- a/src/main/java/com/fasttime/domain/member/service/MemberService.java
+++ b/src/main/java/com/fasttime/domain/member/service/MemberService.java
@@ -29,6 +29,12 @@ public class MemberService {
     private final FcMemberRepository fcMemberRepository;
     private final PasswordEncoder passwordEncoder;
 
+    @Transactional
+    public void deleteExpiredSoftDeletedMembers() {
+        LocalDateTime oneYearAgo = LocalDateTime.now().minusYears(1);
+        memberRepository.deleteByDeletedAtBefore(oneYearAgo);
+    }
+
 
     public void save(MemberDto memberDto) {
 

--- a/src/main/java/com/fasttime/domain/member/service/MemberService.java
+++ b/src/main/java/com/fasttime/domain/member/service/MemberService.java
@@ -44,7 +44,7 @@ public class MemberService {
                 memberDto.getEmail(), oneYearAgo);
 
             if (softDeletedMember.isPresent()) {
-                System.out.println("Member found and trying to recover.");
+                
 
                 Member member = softDeletedMember.get();
 
@@ -52,10 +52,7 @@ public class MemberService {
                 member.setNickname(memberDto.getNickname());
                 save(member);
                 return ResponseDTO.res(HttpStatus.OK, "계정이 성공적으로 복구되었습니다!");
-            } else {
-                System.out.println(
-                    "No soft deleted member found with email: " + memberDto.getEmail());
-            }
+            } 
 
             if (isEmailExistsInMember(memberDto.getEmail())) {
 

--- a/src/main/java/com/fasttime/domain/member/service/ScheduledTasks.java
+++ b/src/main/java/com/fasttime/domain/member/service/ScheduledTasks.java
@@ -1,0 +1,18 @@
+package com.fasttime.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduledTasks {
+
+    private final MemberService memberService;
+
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void deleteExpiredMembers() {
+        memberService.deleteExpiredSoftDeletedMembers();
+    }
+}

--- a/src/main/java/com/fasttime/global/config/SchedulingConfig.java
+++ b/src/main/java/com/fasttime/global/config/SchedulingConfig.java
@@ -1,0 +1,11 @@
+package com.fasttime.global.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@ConditionalOnProperty(name = "scheduling.enabled", havingValue = "true")
+public class SchedulingConfig {
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,3 +12,8 @@ spring:
   mail:
     username: fasttime123
     password: dnwnrlfls123
+  scheduling:
+    enabled: true
+
+
+

--- a/src/test/java/com/fasttime/domain/member/unit/service/AdminServiceTest.java
+++ b/src/test/java/com/fasttime/domain/member/unit/service/AdminServiceTest.java
@@ -55,7 +55,7 @@ public class AdminServiceTest {
                     "testTitle1", "testContent1", false);
             PostCreateServiceDto dto2 = new PostCreateServiceDto
                 (memberRepository.findByEmail("test").get().getId(),
-                    "testTitle2", "testContent2", false);
+                    "testTitle1", "testContent1", false);
           
             PostDetailResponseDto newPost1 = postCommandService.writePost(dto1);
             PostDetailResponseDto newPost2 = postCommandService.writePost(dto2);


### PR DESCRIPTION
## [feat] 탈퇴 계정 유효기간 설정 및 계정 복구 추가

- 회원 탈퇴 시 유효 기간을 1년으로 설정하고, 유효 기간이 지나면 db에서 자동 삭제 기능 추가
- 탈퇴 유효 기간이 지나지 않은 계정(동일 이메일)으로 재가입 시 기존 계정 복구 기능 추가
- join 리팩토링
- 계정 복구 Spring API Docs 추가
- MemberControllerTest 코드 수정