### PR TITLE
[refactor] `ReportStatus` Renaming

### DIFF
--- a/src/main/java/com/fasttime/domain/article/entity/ReportStatus.java
+++ b/src/main/java/com/fasttime/domain/article/entity/ReportStatus.java
@@ -6,8 +6,9 @@ import lombok.Getter;
 public enum ReportStatus {
 
     NORMAL("일반 게시글"),
-    REPORTED("검토 중"),
-    REPORT_REJECTED("검토 완료. 이상 없음");
+    WAIT_FOR_REPORT_REVIEW("검토 중"),
+    REPORT_ACCEPT("검토 완료. 이상 있음"),
+    REPORT_REJECT("검토 완료. 이상 없음");
 
     private final String value;
 

--- a/src/main/java/com/fasttime/domain/article/exception/BadArticleReportStatusException.java
+++ b/src/main/java/com/fasttime/domain/article/exception/BadArticleReportStatusException.java
@@ -1,0 +1,13 @@
+package com.fasttime.domain.article.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import com.fasttime.global.exception.ErrorCode;
+
+public class BadArticleReportStatusException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.BAD_REPORT_STATUS;
+
+    public BadArticleReportStatusException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/fasttime/domain/member/service/AdminService.java
+++ b/src/main/java/com/fasttime/domain/member/service/AdminService.java
@@ -70,7 +70,7 @@ public class AdminService {
 
     public List<ArticlesResponse> findReportedPost(int page) {
         return postRepository.findAllByReportStatus(
-                createSortCondition(page, "createdAt"), ReportStatus.REPORTED)
+                createSortCondition(page, "createdAt"), ReportStatus.WAIT_FOR_REPORT_REVIEW)
             .stream()
             .map(post -> ArticlesResponse.builder()
                 .id(post.getId())
@@ -96,10 +96,11 @@ public class AdminService {
         Article post = postRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("게시글이 없습니다."));
         System.out.println(post.getReportStatus());
-        if (!post.getReportStatus().equals(ReportStatus.REPORTED)) {
+        if (!post.getReportStatus().equals(ReportStatus.WAIT_FOR_REPORT_REVIEW)) {
             throw new AccessException("잘못된 접근입니다.");
         }
-        return ArticleResponse.entityToDto(post);
+//        return ArticleResponse.entityToDto(post);
+        return null;
     }
 
     public void deletePost(Long id) {

--- a/src/main/java/com/fasttime/domain/report/service/ReportService.java
+++ b/src/main/java/com/fasttime/domain/report/service/ReportService.java
@@ -55,7 +55,7 @@ public class ReportService {
 
     private void checkHowManyReportsOfPost(List<Report> reports, Article post) {
         if (is10thReport(reports)) {
-            post.report();
+            post.transToWaitForReview();
         } else if (is20thReport(reports)) {
             post.approveReport(LocalDateTime.now());
         }

--- a/src/main/java/com/fasttime/global/exception/ErrorCode.java
+++ b/src/main/java/com/fasttime/global/exception/ErrorCode.java
@@ -12,9 +12,10 @@ public enum ErrorCode {
     // ADMIN
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 관리자입니다"),
 
-    // POST
+    // ARTICLE
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."),
-    ARTICLE_IS_REPORTED(HttpStatus.UNAUTHORIZED, "해당 게시글은 수정할 수 있는 상태가 아닙니다."),
+    BAD_REPORT_STATUS(HttpStatus.BAD_REQUEST, "신고 후처리를 할 수 없습니다."),
+    REPORT_ACCEPTED_ARTICLE(HttpStatus.UNAUTHORIZED, "신고 처리된 게시글입니다."),
     HAS_NO_PERMISSION_WITH_THIS_ARTICLE(HttpStatus.UNAUTHORIZED, "해당 게시글에 대한 권한이 없습니다."),
 
     // COMMENT

--- a/src/test/java/com/fasttime/domain/article/unit/repository/ArticleRepositoryTest.java
+++ b/src/test/java/com/fasttime/domain/article/unit/repository/ArticleRepositoryTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasttime.domain.article.entity.Article;
 import com.fasttime.domain.article.repository.ArticleRepository;
 import com.fasttime.domain.article.repository.ArticleRepositoryCustom.ArticleQueryResponse;
-import com.fasttime.domain.article.service.ArticleQueryUseCase.ArticleSearchCondition;
+import com.fasttime.domain.article.service.usecase.ArticleQueryUseCase.ArticlesSearchServiceRequest;
 import com.fasttime.domain.member.entity.Member;
 import com.fasttime.domain.member.repository.MemberRepository;
 import java.util.List;
@@ -49,7 +49,7 @@ class ArticleRepositoryTest {
 
             // when
             List<ArticleQueryResponse> result = postRepository
-                .search(ArticleSearchCondition.builder()
+                .search(ArticlesSearchServiceRequest.builder()
                     .title(searchTarget)
                     .pageSize(10)
                     .build());
@@ -75,7 +75,7 @@ class ArticleRepositoryTest {
 
             // when
             List<ArticleQueryResponse> result = postRepository
-                .search(ArticleSearchCondition.builder()
+                .search(ArticlesSearchServiceRequest.builder()
                     .nickname(searchTarget)
                     .pageSize(10)
                     .build());
@@ -101,7 +101,7 @@ class ArticleRepositoryTest {
 
             // when
             List<ArticleQueryResponse> result = postRepository
-                .search(ArticleSearchCondition.builder()
+                .search(ArticlesSearchServiceRequest.builder()
                     .likeCount(searchTarget)
                     .pageSize(10)
                     .build());

--- a/src/test/java/com/fasttime/domain/member/unit/controller/AdminControllerTest.java
+++ b/src/test/java/com/fasttime/domain/member/unit/controller/AdminControllerTest.java
@@ -62,8 +62,8 @@ public class AdminControllerTest {
             ArticleResponse result2 = postCommandService.write(dto2);
             Article postFromDB1 = postRepository.findById(result1.getId()).get();
             Article postFromDB2 = postRepository.findById(result2.getId()).get();
-            postFromDB1.report();
-            postFromDB2.report();
+            postFromDB1.transToWaitForReview();
+            postFromDB2.transToWaitForReview();
             postFromDB1.approveReport(LocalDateTime.now());
             postFromDB2.approveReport(LocalDateTime.now());
 
@@ -110,10 +110,10 @@ public class AdminControllerTest {
             ArticleResponse newPost = postCommandService.write(dto1);
             Article post1 = postRepository.findById(newPost.getId()).get();
 
-            post1.report();
+            post1.transToWaitForReview();
             post1.approveReport(LocalDateTime.now());
             //when, then
-            mockMvc.perform(get("/api/v1/admin/{post_id}", post1.getId()))
+            mockMvc.perform(get("/api/v1/admin/{article_id}", post1.getId()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").exists())
                 .andDo(print());
@@ -130,7 +130,7 @@ public class AdminControllerTest {
             ArticleResponse newPost = postCommandService.write(dto1);
             Article post1 = postRepository.findById(newPost.getId()).get();
 
-            post1.report();
+            post1.transToWaitForReview();
             post1.approveReport(LocalDateTime.now());
             //when, then
             mockMvc.perform(get("/api/v1/admin/{post_id}", 1000L))
@@ -170,7 +170,7 @@ public class AdminControllerTest {
             ArticleResponse newPost = postCommandService.write(dto1);
             Article post1 = postRepository.findById(newPost.getId()).get();
 
-            post1.report();
+            post1.transToWaitForReview();
             post1.approveReport(LocalDateTime.now());
             //when, then
             mockMvc.perform(get("/api/v1/admin/{post_id}/delete", post1.getId()))
@@ -190,7 +190,7 @@ public class AdminControllerTest {
             ArticleResponse newPost = postCommandService.write(dto1);
             Article post1 = postRepository.findById(newPost.getId()).get();
 
-            post1.report();
+            post1.transToWaitForReview();
             post1.approveReport(LocalDateTime.now());
             //when, then
             mockMvc.perform(get("/api/v1/admin/{post_id}/pass", post1.getId()))

--- a/src/test/java/com/fasttime/domain/member/unit/service/AdminServiceTest.java
+++ b/src/test/java/com/fasttime/domain/member/unit/service/AdminServiceTest.java
@@ -10,7 +10,7 @@ import com.fasttime.domain.article.entity.Article;
 import com.fasttime.domain.article.entity.ReportStatus;
 import com.fasttime.domain.article.repository.ArticleRepository;
 import com.fasttime.domain.article.service.ArticleCommandService;
-import com.fasttime.domain.article.service.ArticleCommandUseCase.ArticleCreateServiceRequest;
+import com.fasttime.domain.article.service.usecase.ArticleCommandUseCase.ArticleCreateServiceRequest;
 import java.rmi.AccessException;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -61,8 +61,8 @@ public class AdminServiceTest {
             ArticleResponse newPost2 = postCommandService.write(dto2);
             Article post1 = postRepository.findById(newPost1.getId()).get();
             Article post2 = postRepository.findById(newPost2.getId()).get();
-            post1.report();
-            post2.report();
+            post1.transToWaitForReview();
+            post2.transToWaitForReview();
             post1.approveReport(LocalDateTime.now());
             post2.approveReport(LocalDateTime.now());
 
@@ -105,7 +105,7 @@ public class AdminServiceTest {
             ArticleResponse newPost = postCommandService.write(dto1);
             Article post1 = postRepository.findById(newPost.getId()).get();
 
-            post1.report();
+            post1.transToWaitForReview();
             post1.approveReport(LocalDateTime.now());
             //when
             adminService.deletePost(newPost.getId());
@@ -123,15 +123,14 @@ public class AdminServiceTest {
             ArticleResponse newPost = postCommandService.write(dto1);
             Article post1 = postRepository.findById(newPost.getId()).get();
 
-            post1.report();
-            post1.approveReport(LocalDateTime.now());
+            post1.transToWaitForReview();
 
             //when
             adminService.passPost(post1.getId());
 
             //then
             Assertions.assertThat(postRepository.findById(post1.getId()).get().getReportStatus())
-                .isEqualTo(ReportStatus.REPORT_REJECTED);
+                .isEqualTo(ReportStatus.REPORT_REJECT);
         }
         //IllegalArgumentException
         @DisplayName("잘못된 접근으로 바꿀 수 없다.")

--- a/src/test/java/com/fasttime/domain/report/unit/service/ReportServiceTest.java
+++ b/src/test/java/com/fasttime/domain/report/unit/service/ReportServiceTest.java
@@ -85,7 +85,7 @@ public class ReportServiceTest {
             // given
             CreateReportRequestDTO request = CreateReportRequestDTO.builder().postId(1L)
                 .build();
-            Optional<Article> post = Optional.of(Article.builder().id(1L).build());
+            Optional<Article> post = Optional.of(Article.builder().id(1L).reportStatus(ReportStatus.NORMAL).build());
             Member member = Member.builder().id(1L).build();
             Optional<List<Report>> reports = Optional.of(new ArrayList<>());
             for (long i = 1L; i < 10L; i++) {
@@ -112,7 +112,7 @@ public class ReportServiceTest {
             // given
             CreateReportRequestDTO request = CreateReportRequestDTO.builder().postId(0L)
                 .build();
-            Optional<Article> post = Optional.of(Article.builder().id(0L).build());
+            Optional<Article> post = Optional.of(Article.builder().id(0L).reportStatus(ReportStatus.NORMAL).build());
             Member member = Member.builder().id(0L).build();
             Optional<List<Report>> reports = Optional.of(new ArrayList<>());
             for (long i = 1L; i < 20L; i++) {
@@ -159,7 +159,7 @@ public class ReportServiceTest {
             CreateReportRequestDTO request = CreateReportRequestDTO.builder().postId(1L)
                 .build();
             Optional<Article> post = Optional.of(
-                Article.builder().id(1L).reportStatus(ReportStatus.REPORTED).build());
+                Article.builder().id(1L).reportStatus(ReportStatus.WAIT_FOR_REPORT_REVIEW).build());
             post.get().approveReport(LocalDateTime.now());
             given(postRepository.findById(any(Long.class))).willReturn(post);
 


### PR DESCRIPTION
Motivation:
- Enum ReportStatus 의 naming 들이 다소 모호함을 가지고 있었습니다. 이를 개선하기 위해서 enum class의 type 들을 더 세분화했고, 이름을 재설정하였습니다.

Modification:
- `REPORTED` -> `WAIT_FOR_REPORT_REVIEW`
- `REPORT_ACCEPT` 추가