### PR TITLE
[refactor] 게시글 신고 기능 추출

### DIFF
--- a/src/main/java/com/fasttime/domain/article/service/ArticleReportService.java
+++ b/src/main/java/com/fasttime/domain/article/service/ArticleReportService.java
@@ -1,0 +1,42 @@
+package com.fasttime.domain.article.service;
+
+import com.fasttime.domain.article.entity.Article;
+import com.fasttime.domain.article.exception.ArticleNotFoundException;
+import com.fasttime.domain.article.repository.ArticleRepository;
+import com.fasttime.domain.article.service.usecase.ArticleReportUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+public class ArticleReportService implements ArticleReportUseCase {
+
+    private final ArticleRepository articleRepository;
+
+    public ArticleReportService(ArticleRepository articleRepository) {
+        this.articleRepository = articleRepository;
+    }
+
+    @Override
+    public void reportArticle(ArticleReportServiceRequest request) {
+        Article targetArticle = getById(request);
+        targetArticle.transToWaitForReview();
+    }
+
+    @Override
+    public void acceptReport(ArticleReportServiceRequest request) {
+        Article targetArticle = getById(request);
+        targetArticle.approveReport(request.getRequestTimeStamp());
+    }
+
+    private Article getById(ArticleReportServiceRequest request) {
+        return articleRepository.findById(request.getArticleId())
+            .orElseThrow(() -> new ArticleNotFoundException(request.getArticleId()));
+    }
+
+    @Override
+    public void rejectReport(ArticleReportServiceRequest request) {
+        Article targetArticle = getById(request);
+        targetArticle.rejectReport();
+    }
+}

--- a/src/main/java/com/fasttime/domain/article/service/usecase/ArticleReportUseCase.java
+++ b/src/main/java/com/fasttime/domain/article/service/usecase/ArticleReportUseCase.java
@@ -1,0 +1,25 @@
+package com.fasttime.domain.article.service.usecase;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+public interface ArticleReportUseCase {
+
+    void reportArticle(ArticleReportServiceRequest request);
+
+    void acceptReport(ArticleReportServiceRequest request);
+
+    void rejectReport(ArticleReportServiceRequest request);
+
+    @Getter
+    class ArticleReportServiceRequest {
+
+        private final Long articleId;
+        private final LocalDateTime requestTimeStamp;
+
+        public ArticleReportServiceRequest(Long articleId, LocalDateTime requestTimeStamp) {
+            this.articleId = articleId;
+            this.requestTimeStamp = requestTimeStamp;
+        }
+    }
+}

--- a/src/test/java/com/fasttime/domain/article/unit/service/ArticleReportServiceTest.java
+++ b/src/test/java/com/fasttime/domain/article/unit/service/ArticleReportServiceTest.java
@@ -1,0 +1,201 @@
+package com.fasttime.domain.article.unit.service;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.fasttime.domain.article.entity.Article;
+import com.fasttime.domain.article.entity.ReportStatus;
+import com.fasttime.domain.article.exception.BadArticleReportStatusException;
+import com.fasttime.domain.article.repository.ArticleRepository;
+import com.fasttime.domain.article.service.ArticleReportService;
+import com.fasttime.domain.article.service.usecase.ArticleReportUseCase.ArticleReportServiceRequest;
+import com.fasttime.domain.member.entity.Member;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class ArticleReportServiceTest {
+
+    @InjectMocks
+    private ArticleReportService articleReportService;
+
+    @Mock
+    private ArticleRepository articleRepository;
+
+    @DisplayName("reportArticle 은")
+    @Nested
+    class Context_reportArticle {
+
+        @DisplayName("성공적으로 WAIT_FOR_REVIEW 상태로 전환할 수 있다.")
+        @Test
+        void changeArticleStatus_toWaitForReview_willSuccess() {
+
+            // given
+            LocalDateTime reportTimeStamp = LocalDateTime.now();
+            Article article = Article.builder()
+                .id(1L)
+                .member(createSimpleMember(1L))
+                .title("title")
+                .content("content")
+                .anonymity(true)
+                .reportStatus(ReportStatus.NORMAL)
+                .build();
+
+            given(articleRepository.findById(anyLong())).willReturn(Optional.of(article));
+
+            // when
+            articleReportService.reportArticle(new ArticleReportServiceRequest(article.getId(), reportTimeStamp));
+
+            // then
+            Assertions.assertThat(article.getReportStatus())
+                .isEqualTo(ReportStatus.WAIT_FOR_REPORT_REVIEW);
+        }
+
+        @DisplayName("만약 이미 NORMAL 상태가 아니라면 실패한다.")
+        @EnumSource(value = ReportStatus.class, names = {"REPORT_ACCEPT", "REPORT_REJECT", "WAIT_FOR_REPORT_REVIEW"})
+        @ParameterizedTest
+        void reportStatus_alreadyAccept_willFail(ReportStatus reportStatus) {
+
+            // given
+            LocalDateTime reportTimeStamp = LocalDateTime.now();
+            Article article = Article.builder()
+                .id(1L)
+                .member(createSimpleMember(1L))
+                .title("title")
+                .content("content")
+                .anonymity(true)
+                .reportStatus(reportStatus)
+                .build();
+
+            given(articleRepository.findById(anyLong())).willReturn(Optional.of(article));
+
+            // when then
+            Assertions.assertThatThrownBy(() -> articleReportService.reportArticle(
+                    new ArticleReportServiceRequest(article.getId(), reportTimeStamp)))
+                .isInstanceOf(BadArticleReportStatusException.class);
+        }
+    }
+
+    @DisplayName("acceptReport 은")
+    @Nested
+    class Context_acceptReport {
+
+        @DisplayName("성공적으로 REPORT_ACCEPT 상태로 전환할 수 있다.")
+        @Test
+        void changeArticleStatus_toReportAccept_willSuccess() {
+
+            // given
+            LocalDateTime reportTimeStamp = LocalDateTime.now();
+            Article article = Article.builder()
+                .id(1L)
+                .member(createSimpleMember(1L))
+                .title("title")
+                .content("content")
+                .anonymity(true)
+                .reportStatus(ReportStatus.WAIT_FOR_REPORT_REVIEW)
+                .build();
+
+            given(articleRepository.findById(anyLong())).willReturn(Optional.of(article));
+
+            // when
+            articleReportService.acceptReport(new ArticleReportServiceRequest(article.getId(), reportTimeStamp));
+
+            // then
+            Assertions.assertThat(article.getReportStatus())
+                .isEqualTo(ReportStatus.REPORT_ACCEPT);
+        }
+
+        @DisplayName("만약 이미 WAIT_FOR_REPORT_REVIEW 상태가 아니라면 실패한다.")
+        @EnumSource(value = ReportStatus.class, names = {"REPORT_ACCEPT", "REPORT_REJECT", "NORMAL"})
+        @ParameterizedTest
+        void reportStatus_notWaitForReportReview_willFail(ReportStatus reportStatus) {
+
+            // given
+            LocalDateTime reportTimeStamp = LocalDateTime.now();
+            Article article = Article.builder()
+                .id(1L)
+                .member(createSimpleMember(1L))
+                .title("title")
+                .content("content")
+                .anonymity(true)
+                .reportStatus(reportStatus)
+                .build();
+
+            given(articleRepository.findById(anyLong())).willReturn(Optional.of(article));
+
+            // when then
+            Assertions.assertThatThrownBy(() -> articleReportService.acceptReport(
+                    new ArticleReportServiceRequest(article.getId(), reportTimeStamp)))
+                .isInstanceOf(BadArticleReportStatusException.class);
+        }
+    }
+
+    @DisplayName("rejectReport 은")
+    @Nested
+    class Context_rejectReport {
+
+        @DisplayName("성공적으로 REPORT_REJECT 상태로 전환할 수 있다.")
+        @Test
+        void changeArticleStatus_toWaitForReview_willSuccess() {
+
+            // given
+            LocalDateTime reportTimeStamp = LocalDateTime.now();
+            Article article = Article.builder()
+                .id(1L)
+                .member(createSimpleMember(1L))
+                .title("title")
+                .content("content")
+                .anonymity(true)
+                .reportStatus(ReportStatus.WAIT_FOR_REPORT_REVIEW)
+                .build();
+
+            given(articleRepository.findById(anyLong())).willReturn(Optional.of(article));
+
+            // when
+            articleReportService.rejectReport(new ArticleReportServiceRequest(article.getId(), reportTimeStamp));
+
+            // then
+            Assertions.assertThat(article.getReportStatus())
+                .isEqualTo(ReportStatus.REPORT_REJECT);
+        }
+
+        @DisplayName("만약 이미 WAIT_FOR_REPORT_REVIEW 상태가 아니라면 실패한다.")
+        @EnumSource(value = ReportStatus.class, names = {"REPORT_ACCEPT", "REPORT_REJECT", "NORMAL"})
+        @ParameterizedTest
+        void reportStatus_notWaitForReportReview_willFail(ReportStatus reportStatus) {
+
+            // given
+            LocalDateTime reportTimeStamp = LocalDateTime.now();
+            Article article = Article.builder()
+                .id(1L)
+                .member(createSimpleMember(1L))
+                .title("title")
+                .content("content")
+                .anonymity(true)
+                .reportStatus(reportStatus)
+                .build();
+
+            given(articleRepository.findById(anyLong())).willReturn(Optional.of(article));
+
+            // when then
+            Assertions.assertThatThrownBy(() -> articleReportService.rejectReport(
+                    new ArticleReportServiceRequest(article.getId(), reportTimeStamp)))
+                .isInstanceOf(BadArticleReportStatusException.class);
+        }
+    }
+
+    private static Member createSimpleMember(Long memberId) {
+        return Member.builder().id(memberId).build();
+    }
+}


### PR DESCRIPTION
Motivation:
- 현재 `AdminService` 에서 게시글 신고를 담당하고 있습니다. 문제는 `AdminService` 에서 엔티티를 직접 조회 및 수정을 하고 있다는 것인데, 이는 `AdminService`가 `Article`에 대한 강한 의존성을 갖게 되는 문제점을 낳게 됩니다. 이를 해결하기 위해서 `ArticleService` 측에서 신고 관련 API를 제공하는것이 더 타당하게 여겨집니다.

Modification:
- `ArticleReportUseCase`, `ArticleReportService` 추가
- 테스트 코드 추가