### PR TITLE
[feat] 외부 주입 프로퍼티 Provider 제공

### DIFF
--- a/src/main/java/com/fasttime/domain/article/service/ArticleSettingProvider.java
+++ b/src/main/java/com/fasttime/domain/article/service/ArticleSettingProvider.java
@@ -1,0 +1,16 @@
+package com.fasttime.domain.article.service;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class ArticleSettingProvider {
+
+    @Value("${article.anonymous.nickname:anonymous}")
+    private String anonymousNickname;
+
+    @Value("${article.default.orderField:createdAt}")
+    private String defaultOrderField;
+}


### PR DESCRIPTION
Motivation:
- 현재 매직넘버를 해당 서비스의 `private static final` 으로 제공하고 있습니다. 하지만, 여러 클래스에서 같은 매직넘버가 필요해짐에 따라 Utils 클래스가 필요하게 되었습니다.

- 유틸클래스를 제공하는 것은 좋지만, 이는 객체지향의 관점에서 여러 클래스간의 강한 의존성을 만들 수 있습니다. 이를 해결하기 위해서 스프링의 주입방식을 채택하게 되었습니다.

Modification:
- `ArticleSettingProvider` 생성