### PR TITLE
댓글 작성자만 댓글 수정 삭제할 수 있도록 수정

### DIFF
--- a/src/main/java/com/fasttime/domain/comment/controller/CommentRestController.java
+++ b/src/main/java/com/fasttime/domain/comment/controller/CommentRestController.java
@@ -55,16 +55,16 @@ public class CommentRestController {
 
     @PatchMapping("/{commentId}")
     public ResponseEntity<ResponseDTO<Object>> updateComment(@PathVariable long commentId,
-        @Valid @RequestBody UpdateCommentRequestDTO updateCommentRequestDTO) {
+        @Valid @RequestBody UpdateCommentRequestDTO updateCommentRequestDTO, HttpSession session) {
         return ResponseEntity.status(HttpStatus.OK).body(
             ResponseDTO.res(HttpStatus.OK, "댓글 내용을 성공적으로 수정했습니다.",
-                commentService.updateComment(commentId, updateCommentRequestDTO)));
+                commentService.updateComment(commentId, (long) session.getAttribute("MEMBER"), updateCommentRequestDTO)));
     }
 
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<ResponseDTO<Object>> deleteComment(@PathVariable long commentId) {
+    public ResponseEntity<ResponseDTO<Object>> deleteComment(@PathVariable long commentId, HttpSession session) {
         return ResponseEntity.status(HttpStatus.OK).body(
             ResponseDTO.res(HttpStatus.OK, "댓글을 성공적으로 삭제했습니다.",
-                commentService.deleteComment(commentId)));
+                commentService.deleteComment(commentId, (long) session.getAttribute("MEMBER"))));
     }
 }

--- a/src/main/java/com/fasttime/domain/comment/controller/CommentRestControllerAdvice.java
+++ b/src/main/java/com/fasttime/domain/comment/controller/CommentRestControllerAdvice.java
@@ -1,10 +1,22 @@
 package com.fasttime.domain.comment.controller;
 
+import com.fasttime.domain.comment.exception.NotCommentAuthorException;
+import com.fasttime.global.util.ResponseDTO;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
 @RestControllerAdvice
 public class CommentRestControllerAdvice {
 
+    @ExceptionHandler
+    public ResponseEntity<ResponseDTO<Object>> notCommentAuthorException(
+        NotCommentAuthorException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+            .body(ResponseDTO.res(e.getErrorCode().getHttpStatus(), e.getErrorCode().getMessage()));
+
+    }
 }

--- a/src/main/java/com/fasttime/domain/comment/exception/NotCommentAuthorException.java
+++ b/src/main/java/com/fasttime/domain/comment/exception/NotCommentAuthorException.java
@@ -1,0 +1,13 @@
+package com.fasttime.domain.comment.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import com.fasttime.global.exception.ErrorCode;
+
+public class NotCommentAuthorException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.HAS_NO_PERMISSION_WITH_THIS_COMMENT;
+
+    public NotCommentAuthorException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/fasttime/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fasttime/domain/comment/service/CommentService.java
@@ -8,6 +8,7 @@ import com.fasttime.domain.comment.dto.request.UpdateCommentRequestDTO;
 import com.fasttime.domain.comment.dto.response.CommentResponseDTO;
 import com.fasttime.domain.comment.entity.Comment;
 import com.fasttime.domain.comment.exception.CommentNotFoundException;
+import com.fasttime.domain.comment.exception.NotCommentAuthorException;
 import com.fasttime.domain.comment.repository.CommentRepository;
 import com.fasttime.domain.member.service.MemberService;
 import java.time.LocalDateTime;
@@ -46,15 +47,21 @@ public class CommentService {
         return comments;
     }
 
-    public CommentResponseDTO updateComment(long commentId,
+    public CommentResponseDTO updateComment(long commentId, long memberId,
         UpdateCommentRequestDTO updateCommentRequestDTO) {
         Comment comment = getComment(commentId);
+        if(memberId != comment.getMember().getId()){
+            throw new NotCommentAuthorException();
+        }
         comment.updateContent(updateCommentRequestDTO.getContent());
         return comment.toCommentResponseDTO();
     }
 
-    public CommentResponseDTO deleteComment(long commentId) {
+    public CommentResponseDTO deleteComment(long commentId, long memberId) {
         Comment comment = getComment(commentId);
+        if(memberId != comment.getMember().getId()){
+            throw new NotCommentAuthorException();
+        }
         comment.delete(LocalDateTime.now());
         return comment.toCommentResponseDTO();
     }

--- a/src/main/java/com/fasttime/global/exception/ErrorCode.java
+++ b/src/main/java/com/fasttime/global/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
 
     // COMMENT
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
+    HAS_NO_PERMISSION_WITH_THIS_COMMENT(HttpStatus.UNAUTHORIZED, "댓글 작성자만 해당 댓글 수정/삭제가 가능합니다."),
 
     // RECORD
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 좋아요/싫어요 입니다."),

--- a/src/test/java/com/fasttime/domain/comment/unit/controller/CommentRestControllerTest.java
+++ b/src/test/java/com/fasttime/domain/comment/unit/controller/CommentRestControllerTest.java
@@ -1,6 +1,7 @@
 package com.fasttime.domain.comment.unit.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -388,7 +389,9 @@ public class CommentRestControllerTest {
             // given
             String content = new ObjectMapper().writeValueAsString(
                 UpdateCommentRequestDTO.builder().content("content2").build());
-            given(commentService.updateComment(any(long.class),
+            MockHttpSession session = new MockHttpSession();
+            session.setAttribute("MEMBER", 1L);
+            given(commentService.updateComment(any(long.class), any(long.class),
                 any(UpdateCommentRequestDTO.class))).willReturn(
                 CommentResponseDTO.builder()
                     .commentId(1L)
@@ -406,6 +409,7 @@ public class CommentRestControllerTest {
 
             // when, then
             mockMvc.perform(patch("/api/v1/comments/{commentId}", 1L)
+                    .session(session)
                     .content(content)
                     .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -425,7 +429,7 @@ public class CommentRestControllerTest {
                 .andExpect(jsonPath("$.data.deletedAt").isEmpty())
                 .andDo(print());
             verify(commentService, times(1)).updateComment(any(long.class),
-                any(UpdateCommentRequestDTO.class));
+                any(long.class), any(UpdateCommentRequestDTO.class));
         }
 
         @Nested
@@ -440,8 +444,11 @@ public class CommentRestControllerTest {
                     UpdateCommentRequestDTO.builder()
                         .content(null)
                         .build());
+                MockHttpSession session = new MockHttpSession();
+                session.setAttribute("MEMBER", 1L);
                 // when, then
                 mockMvc.perform(patch("/api/v1/comments/{commentId}", 1L)
+                        .session(session)
                         .content(content)
                         .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isBadRequest())
@@ -450,7 +457,7 @@ public class CommentRestControllerTest {
                     .andExpect(jsonPath("$.data").isEmpty())
                     .andDo(print());
                 verify(commentService, never()).updateComment(any(long.class),
-                    any(UpdateCommentRequestDTO.class));
+                    any(long.class), any(UpdateCommentRequestDTO.class));
             }
 
             @Test
@@ -461,8 +468,11 @@ public class CommentRestControllerTest {
                     UpdateCommentRequestDTO.builder()
                         .content(" ")
                         .build());
+                MockHttpSession session = new MockHttpSession();
+                session.setAttribute("MEMBER", 1L);
                 // when, then
                 mockMvc.perform(patch("/api/v1/comments/{commentId}", 1L)
+                        .session(session)
                         .content(content)
                         .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isBadRequest())
@@ -471,7 +481,7 @@ public class CommentRestControllerTest {
                     .andExpect(jsonPath("$.data").isEmpty())
                     .andDo(print());
                 verify(commentService, never()).updateComment(any(long.class),
-                    any(UpdateCommentRequestDTO.class));
+                    any(long.class), any(UpdateCommentRequestDTO.class));
             }
         }
     }
@@ -484,7 +494,9 @@ public class CommentRestControllerTest {
         @DisplayName("댓글을 삭제할 수 있다.")
         void _willSuccess() throws Exception {
             // given
-            given(commentService.deleteComment(any(long.class))).willReturn(
+            MockHttpSession session = new MockHttpSession();
+            session.setAttribute("MEMBER", 1L);
+            given(commentService.deleteComment(any(long.class), any(long.class))).willReturn(
                 CommentResponseDTO.builder()
                     .commentId(1L)
                     .articleId(1L)
@@ -501,6 +513,7 @@ public class CommentRestControllerTest {
 
             // when, then
             mockMvc.perform(delete("/api/v1/comments/{commentId}", 1L)
+                    .session(session)
                     .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").isNumber())
@@ -518,7 +531,7 @@ public class CommentRestControllerTest {
                 .andExpect(jsonPath("$.data.updatedAt").isString())
                 .andExpect(jsonPath("$.data.deletedAt").isString())
                 .andDo(print());
-            verify(commentService, times(1)).deleteComment(any(long.class));
+            verify(commentService, times(1)).deleteComment(any(long.class), any(long.class));
         }
     }
 }


### PR DESCRIPTION
### 문제 상황
- 댓글 작성자가 아니어도 댓글 ID를 통해 댓글을 수정하거나 삭제할 수 있다. 
- 댓글 수정 및 삭제 요청 회원이 댓글 작성자인지 검증 로직이 부재하다. 

### 해결 방안(개발 내용)
- 댓글 수정 및 삭제 시 댓글 작성자가 맞는지 확인한다. 
- 일치하지 않으면 수정 삭제 불가하다. 