### PR TITLE
댓글 페이징 기능 수정 및 리팩토링

### DIFF
--- a/src/main/java/com/fasttime/domain/comment/controller/CommentRestController.java
+++ b/src/main/java/com/fasttime/domain/comment/controller/CommentRestController.java
@@ -1,12 +1,13 @@
 package com.fasttime.domain.comment.controller;
 
+import com.fasttime.domain.comment.dto.request.CommentPageRequestDTO;
 import com.fasttime.domain.comment.dto.request.CreateCommentRequestDTO;
 import com.fasttime.domain.comment.dto.request.GetCommentsRequestDTO;
 import com.fasttime.domain.comment.dto.request.UpdateCommentRequestDTO;
+import com.fasttime.domain.comment.dto.response.CommentListResponseDTO;
 import com.fasttime.domain.comment.dto.response.CommentResponseDTO;
 import com.fasttime.domain.comment.service.CommentService;
 import com.fasttime.global.util.ResponseDTO;
-import java.util.List;
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -41,28 +42,39 @@ public class CommentRestController {
     }
 
     @GetMapping
-    public ResponseEntity<ResponseDTO<List<CommentResponseDTO>>> getComments(
+    public ResponseEntity<ResponseDTO<CommentListResponseDTO>> getComments(
         @RequestParam(required = false) Long articleId,
         @RequestParam(required = false) Long memberId,
         @RequestParam(required = false) Long parentCommentId,
-        @RequestParam(defaultValue = "10") int pageSize,
-        @RequestParam(defaultValue = "0") int page) {
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int pageSize) {
         return ResponseEntity.status(HttpStatus.OK).body(
             ResponseDTO.res(HttpStatus.OK, "댓글을 성공적으로 조회했습니다.", commentService.getComments(
-                GetCommentsRequestDTO.builder().articleId(articleId).memberId(memberId)
-                    .parentCommentId(parentCommentId).pageSize(pageSize).page(page).build())));
+                GetCommentsRequestDTO.builder()
+                    .articleId(articleId)
+                    .memberId(memberId)
+                    .parentCommentId(parentCommentId)
+                    .build(),
+                CommentPageRequestDTO.builder()
+                    .page(page)
+                    .size(pageSize)
+                    .build().of()
+            )));
     }
 
     @PatchMapping("/{commentId}")
-    public ResponseEntity<ResponseDTO<Object>> updateComment(@PathVariable long commentId,
+    public ResponseEntity<ResponseDTO<CommentResponseDTO>> updateComment(
+        @PathVariable long commentId,
         @Valid @RequestBody UpdateCommentRequestDTO updateCommentRequestDTO, HttpSession session) {
         return ResponseEntity.status(HttpStatus.OK).body(
             ResponseDTO.res(HttpStatus.OK, "댓글 내용을 성공적으로 수정했습니다.",
-                commentService.updateComment(commentId, (long) session.getAttribute("MEMBER"), updateCommentRequestDTO)));
+                commentService.updateComment(commentId, (long) session.getAttribute("MEMBER"),
+                    updateCommentRequestDTO)));
     }
 
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<ResponseDTO<Object>> deleteComment(@PathVariable long commentId, HttpSession session) {
+    public ResponseEntity<ResponseDTO<CommentResponseDTO>> deleteComment(
+        @PathVariable long commentId, HttpSession session) {
         return ResponseEntity.status(HttpStatus.OK).body(
             ResponseDTO.res(HttpStatus.OK, "댓글을 성공적으로 삭제했습니다.",
                 commentService.deleteComment(commentId, (long) session.getAttribute("MEMBER"))));

--- a/src/main/java/com/fasttime/domain/comment/controller/CommentRestControllerAdvice.java
+++ b/src/main/java/com/fasttime/domain/comment/controller/CommentRestControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.fasttime.domain.comment.controller;
 
+import com.fasttime.domain.comment.exception.MultipleSearchConditionException;
 import com.fasttime.domain.comment.exception.NotCommentAuthorException;
 import com.fasttime.global.util.ResponseDTO;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +18,13 @@ public class CommentRestControllerAdvice {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
             .body(ResponseDTO.res(e.getErrorCode().getHttpStatus(), e.getErrorCode().getMessage()));
+    }
 
+    @ExceptionHandler
+    public ResponseEntity<ResponseDTO<Object>> multipleSearchConditionException(
+        MultipleSearchConditionException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+            .body(ResponseDTO.res(e.getErrorCode().getHttpStatus(), e.getErrorCode().getMessage()));
     }
 }

--- a/src/main/java/com/fasttime/domain/comment/dto/request/CommentPageRequestDTO.java
+++ b/src/main/java/com/fasttime/domain/comment/dto/request/CommentPageRequestDTO.java
@@ -1,0 +1,21 @@
+package com.fasttime.domain.comment.dto.request;
+
+import lombok.Builder;
+
+public final class CommentPageRequestDTO {
+
+    private final int page;
+    private final int size;
+
+    @Builder
+    public CommentPageRequestDTO(int page, int size) {
+        this.page = Math.max(page, 0);
+        int DEFAULT_SIZE = 10;
+        int MAX_SIZE = 50;
+        this.size = size > MAX_SIZE ? DEFAULT_SIZE : size;
+    }
+
+    public org.springframework.data.domain.PageRequest of() {
+        return org.springframework.data.domain.PageRequest.of(page, size);
+    }
+}

--- a/src/main/java/com/fasttime/domain/comment/dto/request/GetCommentsRequestDTO.java
+++ b/src/main/java/com/fasttime/domain/comment/dto/request/GetCommentsRequestDTO.java
@@ -9,16 +9,11 @@ public class GetCommentsRequestDTO {
     private final Long articleId;
     private final Long memberId;
     private final Long parentCommentId;
-    private final int pageSize;
-    private final int page;
 
     @Builder
-    private GetCommentsRequestDTO(Long articleId, Long memberId, Long parentCommentId, int pageSize,
-        int page) {
+    private GetCommentsRequestDTO(Long articleId, Long memberId, Long parentCommentId) {
         this.articleId = articleId;
         this.memberId = memberId;
         this.parentCommentId = parentCommentId;
-        this.pageSize = pageSize;
-        this.page = page;
     }
 }

--- a/src/main/java/com/fasttime/domain/comment/dto/response/CommentListResponseDTO.java
+++ b/src/main/java/com/fasttime/domain/comment/dto/response/CommentListResponseDTO.java
@@ -1,0 +1,15 @@
+package com.fasttime.domain.comment.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CommentListResponseDTO {
+
+    private int totalPages;
+    private Boolean isLastPage;
+    private long totalComments;
+    private List<CommentResponseDTO> comments;
+}

--- a/src/main/java/com/fasttime/domain/comment/entity/Comment.java
+++ b/src/main/java/com/fasttime/domain/comment/entity/Comment.java
@@ -74,19 +74,20 @@ public class Comment extends BaseTimeEntity {
     }
 
     public CommentResponseDTO toCommentResponseDTO() {
-        long parentCommentId = -1L;
         boolean isChildComment = this.parentComment != null;
         int deletedChildCommentCount = 0;
-        if (isChildComment) {
-            parentCommentId = this.parentComment.getId();
-        }
+        long parentCommentId = isChildComment? this.parentComment.getId() : -1;
         for (Comment comment : this.childComments) {
             if (comment.isDeleted()) {
                 deletedChildCommentCount++;
             }
         }
-        return CommentResponseDTO.builder().commentId(this.id).articleId(this.article.getId())
-            .memberId(this.member.getId()).nickname(this.member.getNickname()).content(this.content)
+        return CommentResponseDTO.builder()
+            .commentId(this.id)
+            .articleId(this.article.getId())
+            .memberId(this.member.getId())
+            .nickname(this.member.getNickname())
+            .content(this.content)
             .anonymity(this.anonymity).parentCommentId(parentCommentId)
             .childCommentCount(this.childComments.size() - deletedChildCommentCount)
             .createdAt(dateTimeParse(this.getCreatedAt()))

--- a/src/main/java/com/fasttime/domain/comment/exception/MultipleSearchConditionException.java
+++ b/src/main/java/com/fasttime/domain/comment/exception/MultipleSearchConditionException.java
@@ -1,0 +1,13 @@
+package com.fasttime.domain.comment.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import com.fasttime.global.exception.ErrorCode;
+
+public class MultipleSearchConditionException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.CANNOT_MULTIPLE_SEARCH_CONDITION;
+
+    public MultipleSearchConditionException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/fasttime/domain/comment/repository/CommentCustomRepository.java
+++ b/src/main/java/com/fasttime/domain/comment/repository/CommentCustomRepository.java
@@ -2,9 +2,13 @@ package com.fasttime.domain.comment.repository;
 
 import com.fasttime.domain.comment.dto.request.GetCommentsRequestDTO;
 import com.fasttime.domain.comment.entity.Comment;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface CommentCustomRepository {
 
-    List<Comment> findAllBySearchCondition(GetCommentsRequestDTO getCommentsRequestDTO);
+    Page<Comment> findAllBySearchCondition(GetCommentsRequestDTO getCommentsRequestDTO,
+        Pageable pageable);
+
+    Long countByArticleId(long articleId);
 }

--- a/src/main/java/com/fasttime/domain/comment/repository/CommentCustomRepositoryImpl.java
+++ b/src/main/java/com/fasttime/domain/comment/repository/CommentCustomRepositoryImpl.java
@@ -1,13 +1,19 @@
 package com.fasttime.domain.comment.repository;
 
+import static com.fasttime.domain.article.entity.QArticle.article;
 import static com.fasttime.domain.comment.entity.QComment.comment;
+import static com.fasttime.domain.member.entity.QMember.member;
 
 import com.fasttime.domain.comment.dto.request.GetCommentsRequestDTO;
 import com.fasttime.domain.comment.entity.Comment;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import javax.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -19,11 +25,38 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
         this.jpaQueryFactory = new JPAQueryFactory(entityManager);
     }
 
-    public List<Comment> findAllBySearchCondition(GetCommentsRequestDTO getCommentsRequestDTO) {
-        return jpaQueryFactory.selectFrom(comment).leftJoin(comment.parentComment).fetchJoin()
+    @Override
+    public Page<Comment> findAllBySearchCondition(GetCommentsRequestDTO getCommentsRequestDTO,
+        Pageable pageable) {
+        List<Comment> content = jpaQueryFactory
+            .selectFrom(comment)
+            .leftJoin(comment.article, article)
+            .leftJoin(comment.member, member)
+            .leftJoin(comment.parentComment)
+            .fetchJoin()
             .where(createSearchConditionsBuilder(getCommentsRequestDTO))
-            .offset((long) getCommentsRequestDTO.getPage() * getCommentsRequestDTO.getPageSize())
-            .limit(getCommentsRequestDTO.getPageSize()).orderBy(comment.createdAt.asc()).fetch();
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .orderBy(comment.createdAt.asc())
+            .fetch();
+        JPAQuery<Long> countQuery = jpaQueryFactory
+            .select(comment.count())
+            .from(comment)
+            .leftJoin(comment.article, article)
+            .leftJoin(comment.member, member)
+            .leftJoin(comment.parentComment)
+            .where(createSearchConditionsBuilder(getCommentsRequestDTO));
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Long countByArticleId(long articleId) {
+        return jpaQueryFactory
+            .select(comment.count())
+            .from(comment)
+            .leftJoin(comment.article, article)
+            .where(comment.article.id.eq(articleId).and(comment.deletedAt.isNull()))
+            .fetchOne();
     }
 
     private BooleanBuilder createSearchConditionsBuilder(

--- a/src/main/java/com/fasttime/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fasttime/domain/comment/service/CommentService.java
@@ -5,9 +5,11 @@ import com.fasttime.domain.article.service.ArticleQueryService;
 import com.fasttime.domain.comment.dto.request.CreateCommentRequestDTO;
 import com.fasttime.domain.comment.dto.request.GetCommentsRequestDTO;
 import com.fasttime.domain.comment.dto.request.UpdateCommentRequestDTO;
+import com.fasttime.domain.comment.dto.response.CommentListResponseDTO;
 import com.fasttime.domain.comment.dto.response.CommentResponseDTO;
 import com.fasttime.domain.comment.entity.Comment;
 import com.fasttime.domain.comment.exception.CommentNotFoundException;
+import com.fasttime.domain.comment.exception.MultipleSearchConditionException;
 import com.fasttime.domain.comment.exception.NotCommentAuthorException;
 import com.fasttime.domain.comment.repository.CommentRepository;
 import com.fasttime.domain.member.service.MemberService;
@@ -16,6 +18,8 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -33,24 +37,36 @@ public class CommentService {
         Comment parentComment =
             isChildComment ? getComment(createCommentRequestDTO.getParentCommentId()) : null;
         return commentRepository.save(Comment.builder()
-                .article(Article.builder().id(postQueryService.queryById(articleId).getId()).build())
-                .member(memberService.getMember(memberId)).content(createCommentRequestDTO.getContent())
-                .anonymity(createCommentRequestDTO.getAnonymity()).parentComment(parentComment).build())
+                .article(Article.builder()
+                    .id(postQueryService.queryById(articleId).getId())
+                    .build())
+                .member(memberService.getMember(memberId))
+                .content(createCommentRequestDTO.getContent())
+                .anonymity(createCommentRequestDTO.getAnonymity())
+                .parentComment(parentComment)
+                .build())
             .toCommentResponseDTO();
     }
 
-    public List<CommentResponseDTO> getComments(GetCommentsRequestDTO getCommentsRequestDTO) {
+    public CommentListResponseDTO getComments(GetCommentsRequestDTO getCommentsRequestDTO,
+        Pageable pageable) {
+        checkDuplicateCondition(getCommentsRequestDTO);
         List<CommentResponseDTO> comments = new ArrayList<>();
-        commentRepository.findAllBySearchCondition(getCommentsRequestDTO).forEach(comment -> {
-            comments.add(comment.toCommentResponseDTO());
-        });
-        return comments;
+        Page<Comment> commentsFromDB = commentRepository.findAllBySearchCondition(
+            getCommentsRequestDTO, pageable);
+        commentsFromDB.forEach(comment -> comments.add(comment.toCommentResponseDTO()));
+        return CommentListResponseDTO.builder()
+            .totalPages(commentsFromDB.getTotalPages())
+            .isLastPage(commentsFromDB.isLast())
+            .totalComments(getTotalComments(getCommentsRequestDTO, commentsFromDB))
+            .comments(comments)
+            .build();
     }
 
     public CommentResponseDTO updateComment(long commentId, long memberId,
         UpdateCommentRequestDTO updateCommentRequestDTO) {
         Comment comment = getComment(commentId);
-        if(memberId != comment.getMember().getId()){
+        if (memberId != comment.getMember().getId()) {
             throw new NotCommentAuthorException();
         }
         comment.updateContent(updateCommentRequestDTO.getContent());
@@ -59,7 +75,7 @@ public class CommentService {
 
     public CommentResponseDTO deleteComment(long commentId, long memberId) {
         Comment comment = getComment(commentId);
-        if(memberId != comment.getMember().getId()){
+        if (memberId != comment.getMember().getId()) {
             throw new NotCommentAuthorException();
         }
         comment.delete(LocalDateTime.now());
@@ -68,5 +84,39 @@ public class CommentService {
 
     public Comment getComment(Long id) {
         return commentRepository.findById(id).orElseThrow(CommentNotFoundException::new);
+    }
+
+    private void checkDuplicateCondition(GetCommentsRequestDTO getCommentsRequestDTO) {
+        int count = 0;
+        if (isFindByArticleId(getCommentsRequestDTO)) {
+            count++;
+        }
+        if (isFindByMemberId(getCommentsRequestDTO)) {
+            count++;
+        }
+        if (isFindByParentCommentId(getCommentsRequestDTO)) {
+            count++;
+        }
+        if (count > 1) {
+            throw new MultipleSearchConditionException();
+        }
+    }
+
+    private long getTotalComments(GetCommentsRequestDTO getCommentsRequestDTO,
+        Page<Comment> commentsFromDB) {
+        return isFindByArticleId(getCommentsRequestDTO) ? commentRepository.countByArticleId(
+            getCommentsRequestDTO.getArticleId()) : commentsFromDB.getTotalElements();
+    }
+
+    private boolean isFindByArticleId(GetCommentsRequestDTO getCommentsRequestDTO) {
+        return getCommentsRequestDTO.getArticleId() != null;
+    }
+
+    private boolean isFindByMemberId(GetCommentsRequestDTO getCommentsRequestDTO) {
+        return getCommentsRequestDTO.getMemberId() != null;
+    }
+
+    private boolean isFindByParentCommentId(GetCommentsRequestDTO getCommentsRequestDTO) {
+        return getCommentsRequestDTO.getParentCommentId() != null;
     }
 }

--- a/src/main/java/com/fasttime/global/exception/ErrorCode.java
+++ b/src/main/java/com/fasttime/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     // COMMENT
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
     HAS_NO_PERMISSION_WITH_THIS_COMMENT(HttpStatus.UNAUTHORIZED, "댓글 작성자만 해당 댓글 수정/삭제가 가능합니다."),
+    CANNOT_MULTIPLE_SEARCH_CONDITION(HttpStatus.BAD_REQUEST, "다중 조건 검색은 불가합니다."),
 
     // RECORD
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 좋아요/싫어요 입니다."),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,13 +5,13 @@ spring:
     username: root
     password: 1234
   jpa:
+    show-sql: true
     hibernate:
-      show-sql: true
       jdbc:
         time_zone: Asia/Seoul
   mail:
-    username: fasttime123
-    password: dnwnrlfls123
+    username:
+    password:
   scheduling:
     enabled: true
 

--- a/src/test/java/com/fasttime/domain/comment/docs/CommentControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/comment/docs/CommentControllerDocsTest.java
@@ -3,7 +3,6 @@ package com.fasttime.domain.comment.docs;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
@@ -20,23 +19,22 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasttime.docs.RestDocsSupport;
 import com.fasttime.domain.comment.controller.CommentRestController;
 import com.fasttime.domain.comment.dto.request.CreateCommentRequestDTO;
 import com.fasttime.domain.comment.dto.request.GetCommentsRequestDTO;
 import com.fasttime.domain.comment.dto.request.UpdateCommentRequestDTO;
+import com.fasttime.domain.comment.dto.response.CommentListResponseDTO;
 import com.fasttime.domain.comment.dto.response.CommentResponseDTO;
 import com.fasttime.domain.comment.service.CommentService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.commons.util.AnnotationUtils;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.restdocs.constraints.ConstraintDescriptions;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 public class CommentControllerDocsTest extends RestDocsSupport {
 
@@ -125,46 +123,53 @@ public class CommentControllerDocsTest extends RestDocsSupport {
     @Test
     void getComments() throws Exception {
         // given
-        when(commentService.getComments(any(GetCommentsRequestDTO.class))).thenReturn(List.of(
-            CommentResponseDTO.builder()
-                .commentId(1L)
-                .articleId(1L)
-                .memberId(1L)
-                .nickname("깜찍이")
-                .content("얼마나 걸리셨나요?")
-                .anonymity(false)
-                .parentCommentId(-1L)
-                .childCommentCount(2)
-                .createdAt("2024-01-01 12:00:00")
-                .updatedAt(null)
-                .deletedAt(null)
-                .build(),
-            CommentResponseDTO.builder()
-                .commentId(3L)
-                .articleId(1L)
-                .memberId(3L)
-                .nickname("멋쟁이")
-                .content("오...")
-                .anonymity(false)
-                .parentCommentId(-1L)
-                .childCommentCount(0)
-                .createdAt("2024-01-01 14:00:00")
-                .updatedAt(null)
-                .deletedAt(null)
-                .build(),
-            CommentResponseDTO.builder()
-                .commentId(4L)
-                .articleId(1L)
-                .memberId(3L)
-                .nickname("잼민이")
-                .content("굿")
-                .anonymity(false)
-                .parentCommentId(-1L)
-                .createdAt("2024-01-01 14:30:00")
-                .childCommentCount(1)
-                .updatedAt(null)
-                .deletedAt(null)
-                .build()));
+        given(commentService.getComments(any(GetCommentsRequestDTO.class), any(Pageable.class)))
+            .willReturn(CommentListResponseDTO.builder()
+                .totalPages(1)
+                .isLastPage(true)
+                .totalComments(6)
+                .comments(
+                    List.of(
+                        CommentResponseDTO.builder()
+                            .commentId(1L)
+                            .articleId(1L)
+                            .memberId(1L)
+                            .nickname("깜찍이")
+                            .content("얼마나 걸리셨나요?")
+                            .anonymity(false)
+                            .parentCommentId(-1L)
+                            .childCommentCount(2)
+                            .createdAt("2024-01-01 12:00:00")
+                            .updatedAt(null)
+                            .deletedAt(null)
+                            .build(),
+                        CommentResponseDTO.builder()
+                            .commentId(3L)
+                            .articleId(1L)
+                            .memberId(3L)
+                            .nickname("멋쟁이")
+                            .content("오...")
+                            .anonymity(false)
+                            .parentCommentId(-1L)
+                            .childCommentCount(0)
+                            .createdAt("2024-01-01 14:00:00")
+                            .updatedAt(null)
+                            .deletedAt(null)
+                            .build(),
+                        CommentResponseDTO.builder()
+                            .commentId(4L)
+                            .articleId(1L)
+                            .memberId(3L)
+                            .nickname("잼민이")
+                            .content("굿")
+                            .anonymity(false)
+                            .parentCommentId(-1L)
+                            .createdAt("2024-01-01 14:30:00")
+                            .childCommentCount(1)
+                            .updatedAt(null)
+                            .deletedAt(null)
+                            .build()))
+                .build());
 
         // when, then
         mockMvc.perform(get("/api/v1/comments")
@@ -183,27 +188,35 @@ public class CommentControllerDocsTest extends RestDocsSupport {
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
-                    fieldWithPath("data").type(JsonFieldType.ARRAY).description("응답데이터"),
-                    fieldWithPath("data[].commentId").type(JsonFieldType.NUMBER)
+                    fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답데이터"),
+                    fieldWithPath("data.totalPages").type(JsonFieldType.NUMBER)
+                        .description("총 페이지 수"),
+                    fieldWithPath("data.isLastPage").type(JsonFieldType.BOOLEAN)
+                        .description("마지막 페이지 여부"),
+                    fieldWithPath("data.totalComments").type(JsonFieldType.NUMBER)
+                        .description("총 댓글 수"),
+                    fieldWithPath("data.comments").type(JsonFieldType.ARRAY).description("댓글 목록"),
+                    fieldWithPath("data.comments[].commentId").type(JsonFieldType.NUMBER)
                         .description("댓글 식별자"),
-                    fieldWithPath("data[].articleId").type(JsonFieldType.NUMBER)
+                    fieldWithPath("data.comments[].articleId").type(JsonFieldType.NUMBER)
                         .description("게시글 식별자"),
-                    fieldWithPath("data[].memberId").type(JsonFieldType.NUMBER)
+                    fieldWithPath("data.comments[].memberId").type(JsonFieldType.NUMBER)
                         .description("회원 식별자"),
-                    fieldWithPath("data[].nickname").type(JsonFieldType.STRING)
+                    fieldWithPath("data.comments[].nickname").type(JsonFieldType.STRING)
                         .description("작성자 닉네임"),
-                    fieldWithPath("data[].content").type(JsonFieldType.STRING).description("댓글 내용"),
-                    fieldWithPath("data[].anonymity").type(JsonFieldType.BOOLEAN)
+                    fieldWithPath("data.comments[].content").type(JsonFieldType.STRING)
+                        .description("댓글 내용"),
+                    fieldWithPath("data.comments[].anonymity").type(JsonFieldType.BOOLEAN)
                         .description("익명 여부"),
-                    fieldWithPath("data[].parentCommentId").type(JsonFieldType.NUMBER)
+                    fieldWithPath("data.comments[].parentCommentId").type(JsonFieldType.NUMBER)
                         .description("부모 댓글 식별자"),
-                    fieldWithPath("data[].childCommentCount").type(JsonFieldType.NUMBER)
+                    fieldWithPath("data.comments[].childCommentCount").type(JsonFieldType.NUMBER)
                         .description("대댓글 개수"),
-                    fieldWithPath("data[].createdAt").type(JsonFieldType.STRING)
+                    fieldWithPath("data.comments[].createdAt").type(JsonFieldType.STRING)
                         .description("등록 일시"),
-                    fieldWithPath("data[].updatedAt").type(JsonFieldType.STRING)
+                    fieldWithPath("data.comments[].updatedAt").type(JsonFieldType.STRING)
                         .description("수정 일시").optional(),
-                    fieldWithPath("data[].deletedAt").type(JsonFieldType.STRING)
+                    fieldWithPath("data.comments[].deletedAt").type(JsonFieldType.STRING)
                         .description("삭제 일시").optional())));
     }
 

--- a/src/test/java/com/fasttime/domain/comment/unit/service/CommentServiceTest.java
+++ b/src/test/java/com/fasttime/domain/comment/unit/service/CommentServiceTest.java
@@ -14,9 +14,11 @@ import com.fasttime.domain.article.entity.Article;
 import com.fasttime.domain.article.entity.ReportStatus;
 import com.fasttime.domain.article.exception.ArticleNotFoundException;
 import com.fasttime.domain.article.service.ArticleQueryService;
+import com.fasttime.domain.comment.dto.request.CommentPageRequestDTO;
 import com.fasttime.domain.comment.dto.request.CreateCommentRequestDTO;
 import com.fasttime.domain.comment.dto.request.GetCommentsRequestDTO;
 import com.fasttime.domain.comment.dto.request.UpdateCommentRequestDTO;
+import com.fasttime.domain.comment.dto.response.CommentListResponseDTO;
 import com.fasttime.domain.comment.dto.response.CommentResponseDTO;
 import com.fasttime.domain.comment.entity.Comment;
 import com.fasttime.domain.comment.exception.CommentNotFoundException;
@@ -38,6 +40,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 @Transactional
 @ExtendWith(MockitoExtension.class)
@@ -339,6 +343,10 @@ public class CommentServiceTest {
             GetCommentsRequestDTO getCommentsRequestDTO = GetCommentsRequestDTO.builder()
                 .articleId(1L)
                 .build();
+            Pageable pageable = CommentPageRequestDTO.builder()
+                .page(0)
+                .size(10)
+                .build().of();
             Comment comment1 = Comment.builder()
                 .id(1L)
                 .article(newArticle())
@@ -365,21 +373,22 @@ public class CommentServiceTest {
                 .build();
             comment1.getChildComments().add(comment2);
             given(commentRepository.findAllBySearchCondition(
-                any(GetCommentsRequestDTO.class))).willReturn(List.of(comment1, comment3));
+                any(GetCommentsRequestDTO.class), any(Pageable.class))).willReturn(
+                new PageImpl<>(List.of(comment1, comment3)));
 
             // when
-            List<CommentResponseDTO> result = commentService.getComments(getCommentsRequestDTO);
+            CommentListResponseDTO result = commentService.getComments(getCommentsRequestDTO,
+                pageable);
 
             // then
-            assertThat(result).isNotEmpty();
-            assertThat(result.get(0)).extracting("commentId", "articleId", "memberId", "nickname",
-                    "content", "anonymity", "parentCommentId", "childCommentCount")
+            assertThat(result.getComments().get(0)).extracting("commentId", "articleId", "memberId",
+                    "nickname", "content", "anonymity", "parentCommentId", "childCommentCount")
                 .containsExactly(1L, 1L, 1L, "nickname", "content1", false, -1L, 1);
-            assertThat(result.get(1)).extracting("commentId", "articleId", "memberId", "nickname",
-                    "content", "anonymity", "parentCommentId", "childCommentCount")
+            assertThat(result.getComments().get(1)).extracting("commentId", "articleId", "memberId",
+                    "nickname", "content", "anonymity", "parentCommentId", "childCommentCount")
                 .containsExactly(3L, 1L, 1L, "nickname", "content3", false, -1L, 0);
             verify(commentRepository, times(1)).findAllBySearchCondition(
-                any(GetCommentsRequestDTO.class));
+                any(GetCommentsRequestDTO.class), any(Pageable.class));
         }
 
         @Test
@@ -389,6 +398,10 @@ public class CommentServiceTest {
             GetCommentsRequestDTO getCommentsRequestDTO = GetCommentsRequestDTO.builder()
                 .memberId(1L)
                 .build();
+            Pageable pageable = CommentPageRequestDTO.builder()
+                .page(0)
+                .size(10)
+                .build().of();
             Comment comment1 = Comment.builder()
                 .id(1L)
                 .article(newArticle())
@@ -414,25 +427,25 @@ public class CommentServiceTest {
                 .build();
             comment1.getChildComments().add(comment2);
             given(commentRepository.findAllBySearchCondition(
-                any(GetCommentsRequestDTO.class))).willReturn(
-                List.of(comment1, comment2, comment3));
+                any(GetCommentsRequestDTO.class), any(Pageable.class))).willReturn(
+                new PageImpl<>(List.of(comment1, comment2, comment3)));
 
             // when
-            List<CommentResponseDTO> result = commentService.getComments(getCommentsRequestDTO);
+            CommentListResponseDTO result = commentService.getComments(getCommentsRequestDTO,
+                pageable);
 
             // then
-            assertThat(result).isNotEmpty();
-            assertThat(result.get(0)).extracting("commentId", "articleId", "memberId", "nickname",
-                    "content", "anonymity", "parentCommentId", "childCommentCount")
+            assertThat(result.getComments().get(0)).extracting("commentId", "articleId", "memberId",
+                    "nickname", "content", "anonymity", "parentCommentId", "childCommentCount")
                 .containsExactly(1L, 1L, 1L, "nickname", "content1", false, -1L, 1);
-            assertThat(result.get(1)).extracting("commentId", "articleId", "memberId", "nickname",
-                    "content", "anonymity", "parentCommentId", "childCommentCount")
+            assertThat(result.getComments().get(1)).extracting("commentId", "articleId", "memberId",
+                    "nickname", "content", "anonymity", "parentCommentId", "childCommentCount")
                 .containsExactly(2L, 1L, 1L, "nickname", "content2", false, 1L, 0);
-            assertThat(result.get(2)).extracting("commentId", "articleId", "memberId", "nickname",
-                    "content", "anonymity", "parentCommentId", "childCommentCount")
+            assertThat(result.getComments().get(2)).extracting("commentId", "articleId", "memberId",
+                    "nickname", "content", "anonymity", "parentCommentId", "childCommentCount")
                 .containsExactly(3L, 1L, 1L, "nickname", "content3", false, -1L, 0);
             verify(commentRepository, times(1)).findAllBySearchCondition(
-                any(GetCommentsRequestDTO.class));
+                any(GetCommentsRequestDTO.class), any(Pageable.class));
         }
 
         @Test
@@ -442,6 +455,10 @@ public class CommentServiceTest {
             GetCommentsRequestDTO getCommentsRequestDTO = GetCommentsRequestDTO.builder()
                 .parentCommentId(1L)
                 .build();
+            Pageable pageable = CommentPageRequestDTO.builder()
+                .page(0)
+                .size(10)
+                .build().of();
             Comment comment1 = Comment.builder()
                 .id(1L)
                 .article(newArticle())
@@ -460,35 +477,41 @@ public class CommentServiceTest {
                 .build();
             comment1.getChildComments().add(comment2);
             given(commentRepository.findAllBySearchCondition(
-                any(GetCommentsRequestDTO.class))).willReturn(List.of(comment2));
+                any(GetCommentsRequestDTO.class), any(Pageable.class))).willReturn(
+                new PageImpl<>(List.of(comment2)));
 
             // when
-            List<CommentResponseDTO> result = commentService.getComments(getCommentsRequestDTO);
+            CommentListResponseDTO result = commentService.getComments(getCommentsRequestDTO,
+                pageable);
 
             // then
-            assertThat(result).isNotEmpty();
-            assertThat(result.get(0)).extracting("commentId", "articleId", "memberId", "nickname",
-                    "content", "anonymity", "parentCommentId", "childCommentCount")
+            assertThat(result.getComments().get(0)).extracting("commentId", "articleId", "memberId",
+                    "nickname", "content", "anonymity", "parentCommentId", "childCommentCount")
                 .containsExactly(2L, 1L, 1L, "nickname", "content2", false, 1L, 0);
             verify(commentRepository, times(1)).findAllBySearchCondition(
-                any(GetCommentsRequestDTO.class));
+                any(GetCommentsRequestDTO.class), any(Pageable.class));
         }
 
         @Test
         @DisplayName("댓글을 찾을 수 없으면 빈 리스트를 반환한다.")
         void CommentNotFound_willFail() {
             // given
+            Pageable pageable = CommentPageRequestDTO.builder()
+                .page(0)
+                .size(10)
+                .build().of();
             given(commentRepository.findAllBySearchCondition(
-                any(GetCommentsRequestDTO.class))).willReturn(new ArrayList<>());
+                any(GetCommentsRequestDTO.class), any(Pageable.class))).willReturn(
+                new PageImpl<>(new ArrayList<>()));
 
             // when
-            List<CommentResponseDTO> result = commentService.getComments(
-                GetCommentsRequestDTO.builder().articleId(1L).build());
+            CommentListResponseDTO result = commentService.getComments(
+                GetCommentsRequestDTO.builder().articleId(1L).build(), pageable);
 
             // then
-            assertThat(result).isEmpty();
+            assertThat(result.getComments()).isEmpty();
             verify(commentRepository, times(1)).findAllBySearchCondition(
-                any(GetCommentsRequestDTO.class));
+                any(GetCommentsRequestDTO.class), any(Pageable.class));
         }
     }
 


### PR DESCRIPTION
### 개발 내용
- 댓글 페이징 기능 수정
  - 댓글 페이징에 Pageable 사용하도록 수정
-  댓글 목록 조회 시 총 페이지 수, 댓글 전체 수, 마지막 페이지 여부 정보 추가 응답
- 댓글 목록 다중 조건 조회 예외 처리 추가
- 댓글 목록 조회 기능의 수정에 따른 테스트 코드 수정